### PR TITLE
bin/mongo: connect to sharelatex db

### DIFF
--- a/bin/mongo
+++ b/bin/mongo
@@ -16,7 +16,7 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
 fi
 
 function __main__() {
-  exec "$TOOLKIT_ROOT/bin/docker-compose" exec mongo mongo
+  exec "$TOOLKIT_ROOT/bin/docker-compose" exec mongo mongo sharelatex
 }
 
 __main__ "$@"


### PR DESCRIPTION
As a convenience, connect to the sharelatex database when using bin/mongo.