### PR TITLE
Update quick-start-guide.md

### DIFF
--- a/doc/quick-start-guide.md
+++ b/doc/quick-start-guide.md
@@ -17,7 +17,7 @@ are available on your system.
 First, let's clone this git repository to your machine:
 
 ```sh
-$ git clone git@github.com:overleaf/toolkit.git ./overleaf
+$ git clone https://github.com/overleaf/toolkit.git ./overleaf
 ```
 
 Next let's move into this directory:


### PR DESCRIPTION
When using git clone via https instead of ssh this works also w/o a public key
and then this file is more conform to the README file.