### PR TITLE
Configure port binding for main container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+
+## 2020-10-09
+### Added
+- Add `SHARELATEX_PORT` option to `overleaf.rc` file, which defaults
+  to `80`, same as the previous hard-coded value. ([documentation](./doc/overleaf-rc.md))

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -84,6 +84,7 @@ function __main__() {
   # Export vars for use in docker-compose files
   export IMAGE="$full_image_spec"
   export SHARELATEX_DATA_PATH
+  export SHARELATEX_PORT
   export DOCKER_SOCKET_PATH
   export MONGO_IMAGE
   export MONGO_DATA_PATH

--- a/bin/doctor
+++ b/bin/doctor
@@ -189,6 +189,9 @@ function check_config_files() {
           fi
           print_point 2 "SIBLING_CONTAINERS_ENABLED: $SIBLING_CONTAINERS_ENABLED"
         fi
+        if [[ "${SHARELATEX_PORT:-null}" != "null" ]]; then
+          print_point 2 "SHARELATEX_PORT: ${SHARELATEX_PORT}"
+        fi
 
         print_point 2 "MONGO_ENABLED: $MONGO_ENABLED"
         if [[ "${MONGO_URL:-null}" != "null" ]]; then

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -46,3 +46,5 @@ The `config/version` file contains the version number of the docker images that 
 ## The `docker-compose.override.yml` File
 
 If present, the `config/docker-compose.override.yml` file will be included in the invocation to `docker-compose`. This is useful for overriding configuration specific to docker-compose.
+
+See the [docker-compose documentation](https://docs.docker.com/compose/extends/#adding-and-overriding-configuration) for more details.

--- a/doc/overleaf-rc.md
+++ b/doc/overleaf-rc.md
@@ -22,6 +22,13 @@ Sets the path to the directory that will be mounted into the main `sharelatex` c
 - Default: data/sharelatex
 
 
+### `SHARELATEX_PORT`
+
+Sets the host port that the container will bind to. For example, if this is set to `8099`, then the web interface will be available on `http://localhost:8099`.
+
+- Default: 80
+
+
 ### `SERVER_PRO`
 
 When set to `true`, tells the toolkit to use the Server Pro image (`quay.io/sharelatex/sharelatex-pro`), rather than the default Community Edition image (`sharelatex/sharelatex`). 

--- a/lib/config-seed/overleaf.rc
+++ b/lib/config-seed/overleaf.rc
@@ -5,6 +5,7 @@ PROJECT_NAME=overleaf
 # Sharelatex container
 SHARELATEX_DATA_PATH=data/sharelatex
 SERVER_PRO=false
+SHARELATEX_PORT=80
 
 # Sibling Containers
 SIBLING_CONTAINERS_ENABLED=false

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -9,7 +9,7 @@ services:
         volumes:
             - "${SHARELATEX_DATA_PATH}:/var/lib/sharelatex"
         ports:
-            - 80:80
+            - "${SHARELATEX_PORT:-80}:80"
         environment:
           SHARELATEX_MONGO_URL: "${MONGO_URL}"
           SHARELATEX_REDIS_HOST: "${REDIS_HOST}"


### PR DESCRIPTION
## Description

Add `SHARELATEX_PORT` option to `overleaf.rc`, default to 80.

This allows a user to configure the host port that the sharelatex
container will bind to. Previously this was hard-coded to port 80, which
can cause problems on systems with something already bound to that port.

This is a safe upgrade for existing users, as the docker-compose machinery will default to port 80 if the variable is not set.

We will need to add this to a changelog before deployment.


## Related issues / Pull Requests

- Fixes https://github.com/overleaf/toolkit/issues/12


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
