### PR TITLE
Remove <div> from custom footer

### DIFF
--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -35,7 +35,7 @@ TEXMFVAR=/var/lib/sharelatex/tmp/texmf-var
 # SHARELATEX_EMAIL_SMTP_PASS=
 # SHARELATEX_EMAIL_SMTP_TLS_REJECT_UNAUTH=true
 # SHARELATEX_EMAIL_SMTP_IGNORE_TLS=false
-# SHARELATEX_CUSTOM_EMAIL_FOOTER=<div>This system is run by department x </div>
+# SHARELATEX_CUSTOM_EMAIL_FOOTER=This system is run by department x
 
 ################
 ## Server Pro ##


### PR DESCRIPTION

## Description

Deletes the `<div>` since the recommendation is not to use <div> within html emails

## Related issues / Pull Requests

counterpart of https://github.com/overleaf/overleaf/pull/798