### PR TITLE
bin/up: pass flags to docker-compose

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -15,6 +15,15 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
   exit 1
 fi
 
+function usage() {
+  echo "Usage: bin/up [FLAGS...]"
+  echo ""
+  echo "A wrapper around 'docker-compose up'."
+  echo ""
+  echo "This program will pass any extra flags to docker-compose,"
+  echo "for example: 'bin/up -d' will run in detached mode"
+}
+
 function check_config() {
   if [[ ! -f "$TOOLKIT_ROOT/config/overleaf.rc" ]] \
       || [[ ! -f "$TOOLKIT_ROOT/config/variables.env" ]]; then
@@ -24,8 +33,12 @@ function check_config() {
 }
 
 function __main__() {
+  if [[ "${1:-null}" == "help" ]] || [[ "${1:-null}" == "--help" ]]; then
+    usage
+    exit
+  fi
   check_config
-  exec "$TOOLKIT_ROOT/bin/docker-compose" up
+  exec "$TOOLKIT_ROOT/bin/docker-compose" up "$@"
 }
 
 __main__ "$@"


### PR DESCRIPTION
## Description

- Pass any extra flags on `bin/up`, to the underlying `docker-compose` call, for example, the `-d` flag to run in detached mode.
- Add handling for the `--help` and `help` arguments


## Related issues / Pull Requests
Contributes to https://github.com/overleaf/toolkit/issues/20


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
