### PR TITLE
Document how to apply configuration changes

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -8,6 +8,12 @@ This document describes the configuration files that are used to configure the O
 All user-owned configuration files are found in the `config/` directory.
 This directory is excluded from the git revision control system, so it will not be changed by updating the toolkit code. The toolkit will not change any data in the `config/` directory without your permission.
 
+Note that changes to the configuration files will not be automatically applied
+to existing containers, even if the container is stopped and restarted (with
+`bin/stop` and `bin/start`). To apply the changes, run `bin/up`, and
+`docker-compose` will automatically apply the configuration changes to a new
+container. (Or, run `bin/up -d`, if you prefer to not attach to the docker logs)
+
 
 ## Initializing the Configuration
 


### PR DESCRIPTION
## Description

When a user changes variables in `config/variables.env`, they need to run `bin/up` to actually re-create the container. This PR adds documentation to that effect.


## Related issues / Pull Requests
Contributes to https://github.com/overleaf/toolkit/issues/20


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
