### PR TITLE
[bin/upgrade] display changelog diff before pulling changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+### Added
+- `bin/upgrade` displays any changes to the changelog and requires extra
+   confirmation before applying the remote changes to the local branch.
+
 ## 2020-11-19
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to 2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## TBD
 ### Added
-- `bin/upgrade` displays any changes to the changelog and requires extra
+- `bin/upgrade` displays any changes to the changelog and prompts for
    confirmation before applying the remote changes to the local branch.
 
 ## 2020-11-19

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -166,16 +166,7 @@ function handle_git_update() {
     echo "No code update available for download"
   else
     echo "Code update available for download!"
-
-    local should_fetch="n"
-    read -r -p "Proceed to download update? [y/n] " should_fetch
-
-    if [[ ! "$should_fetch" =~ [Yy] ]]; then
-      echo "Continuing without downloading update"
-    else
-      echo "Downloading new code..."
-      git -C "$TOOLKIT_ROOT" fetch origin "$current_branch"
-    fi
+    git -C "$TOOLKIT_ROOT" fetch origin "$current_branch"
   fi
 
   if ! is_up_to_date_with_remote "$current_branch"; then

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -47,6 +47,43 @@ function git_pull_available() {
   fi
 }
 
+function git_diff() {
+  git -C "$TOOLKIT_ROOT" diff "$@"
+}
+
+function is_up_to_date_with_remote() {
+  local branch="$1"
+  git_diff --quiet HEAD "origin/$branch"
+}
+
+function show_changes() {
+  local branch="$1"
+
+  if git_diff --quiet HEAD "origin/$branch" -- CHANGELOG.md; then
+    echo "No changelog available"
+    return 0
+  fi
+
+  # show CHANGELOG.md changes
+  # git diff --unified=0  hide diff context
+  # tail -n+6             hide the patch header
+
+  # Example output
+  #
+  # Changelog:
+  # ----------
+  # +## 2020-11-19
+  # +### Added
+  # +- Updated ...
+  # ----------
+
+  echo "Changelog:"
+  echo "----------"
+  git_diff --color --unified=0 HEAD "origin/$branch" -- CHANGELOG.md \
+  | tail -n+6
+  echo "----------"
+}
+
 function handle_image_upgrade() {
   local user_image_version="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
   local seed_image_version="$(head -n 1 "$TOOLKIT_ROOT/lib/config-seed/version")"
@@ -126,17 +163,32 @@ function handle_git_update() {
   echo "Checking for code update..."
 
   if ! git_pull_available "$current_branch"; then
-    echo "No code update available"
+    echo "No code update available for download"
   else
-    echo "Code update available! (current commit is $current_commit)"
+    echo "Code update available for download!"
+
+    local should_fetch="n"
+    read -r -p "Proceed to download update? [y/n] " should_fetch
+
+    if [[ ! "$should_fetch" =~ [Yy] ]]; then
+      echo "Continuing without downloading update"
+    else
+      echo "Downloading new code..."
+      git -C "$TOOLKIT_ROOT" fetch origin "$current_branch"
+    fi
+  fi
+
+  if ! is_up_to_date_with_remote "$current_branch"; then
+    show_changes "$current_branch"
 
     local should_pull="n"
-    read -r -p "Proceed to pull update? [y/n] " should_pull
+    read -r -p "Perform code update? [y/n] " should_pull
 
     if [[ ! "$should_pull" =~ [Yy] ]]; then
-      echo "Continuing without pulling update"
+      echo "Continuing without updating code"
     else
-      echo "Pulling new code..."
+      echo "Current commit is $current_commit"
+      echo "Updating code..."
       git -C "$TOOLKIT_ROOT" pull origin "$current_branch"
     fi
   fi


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

For https://github.com/overleaf/issues/issues/3737

This PR enhances the `bin/upgrade` script with displaying of changelog entries.

Download (fetch) and applying (pull) of changes is split into two stages now.
We need to fetch the changelog, ask for user confirmation of the changes and only
 then run the actual pull.

See this demo terminal session:

```
toolkit$ git reset --soft origin/master
toolkit$ bin/upgrade 
Warning: current branch is not master, 'jpa-display-changelog' instead
Checking for code update...
No code update available for download
Changelog:
----------
+## TBD
+### Added
+- `bin/upgrade` displays any changes to the changelog and requires extra
+   confirmation before applying the remote changes to the local branch.
+
----------
Perform code update? [y/n] y
Current commit is 0e38cf1
Updating code...
From github.com:overleaf/toolkit
 * branch            jpa-display-changelog -> FETCH_HEAD
Updating 0e38cf1..45368bb
Fast-forward
 CHANGELOG.md |  5 +++++
 bin/upgrade  | 62 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----
 2 files changed, 62 insertions(+), 5 deletions(-)
...
```

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

For https://github.com/overleaf/issues/issues/3737

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
