### PR TITLE
Add data paths to doctor output

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -202,6 +202,9 @@ function check_config_files() {
         if [[ "${MONGO_IMAGE:-null}" != "null" ]]; then
           print_point 2 "MONGO_IMAGE: $MONGO_IMAGE"
         fi
+        if [[ "${MONGO_DATA_PATH:-null}" != "null" ]]; then
+          print_point 2 "MONGO_DATA_PATH: $MONGO_DATA_PATH"
+        fi
 
         print_point 2 "REDIS_ENABLED: $REDIS_ENABLED"
         if [[ "${REDIS_HOST:-null}" != "null" ]]; then
@@ -212,6 +215,9 @@ function check_config_files() {
         fi
         if [[ "${REDIS_IMAGE:-null}" != "null" ]]; then
           print_point 2 "REDIS_IMAGE: $REDIS_IMAGE"
+        fi
+        if [[ "${REDIS_DATA_PATH:-null}" != "null" ]]; then
+          print_point 2 "REDIS_DATA_PATH: $REDIS_DATA_PATH"
         fi
       fi
     fi


### PR DESCRIPTION
To help with debugging, this adds `MONGO_DATA_PATH` and `REDIS_DATA_PATH` to the output of `bin/doctor`, if they're set.