### PR TITLE
Add example of nginx config variables

### DIFF
--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -12,6 +12,10 @@ EMAIL_CONFIRMATION_DISABLED=true
 # see https://github.com/overleaf/overleaf/issues/695
 TEXMFVAR=/var/lib/sharelatex/tmp/texmf-var
 
+## Nginx
+# NGINX_WORKER_PROCESSES=4
+# NGINX_WORKER_CONNECTIONS=768
+
 ## Set for SSL via nginx-proxy
 #VIRTUAL_HOST=103.112.212.22
 


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Adds the new nginx config vars (commented out) to `/lib/config-seed/variables.env`, to serve as examples for users.


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

- Part of https://github.com/overleaf/issues/issues/3925
- Sibling of https://github.com/overleaf/overleaf/pull/853


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
