### PR TITLE
Added `TEX_LIVE_` to variables.env

### DIFF
--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -61,5 +61,7 @@ TEXMFVAR=/var/lib/sharelatex/tmp/texmf-var
 # SHARELATEX_TEMPLATES_USER_ID=578773160210479700917ee5
 # SHARELATEX_NEW_PROJECT_TEMPLATE_LINKS=[{"name":"All Templates","url":"/templates/all"}]
 
+# TEX_LIVE_DOCKER_IMAGE: "quay.io/sharelatex/texlive-full:2020.1"
+# ALL_TEX_LIVE_DOCKER_IMAGES: "quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1"
 
 # SHARELATEX_PROXY_LEARN="true"

--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -61,7 +61,7 @@ TEXMFVAR=/var/lib/sharelatex/tmp/texmf-var
 # SHARELATEX_TEMPLATES_USER_ID=578773160210479700917ee5
 # SHARELATEX_NEW_PROJECT_TEMPLATE_LINKS=[{"name":"All Templates","url":"/templates/all"}]
 
-# TEX_LIVE_DOCKER_IMAGE: "quay.io/sharelatex/texlive-full:2020.1"
-# ALL_TEX_LIVE_DOCKER_IMAGES: "quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1"
+TEX_LIVE_DOCKER_IMAGE="quay.io/sharelatex/texlive-full:2020.1"
+ALL_TEX_LIVE_DOCKER_IMAGES="quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1"
 
 # SHARELATEX_PROXY_LEARN="true"


### PR DESCRIPTION
## Description

When using the legacy `docker-compose.yml` any new user is stuck with the old default TexLive images hardcoded in the `Dockerfile` of Server Pro.

```
ENV TEX_LIVE_DOCKER_IMAGE "quay.io/sharelatex/texlive-full:2017.1"
ENV ALL_TEX_LIVE_DOCKER_IMAGES "quay.io/sharelatex/texlive-full:2016.1,quay.io/sharelatex/texlive-full:2017.1"
```

Defaulting to these legacy versions is a hassle, and has caused some trouble with potential users.

We haven't updated this because doing that would introduce breaking changes for those users that aren't overriding `TEX_LIVE_DOCKER_IMAGE` and `ALL_TEX_LIVE_DOCKER_IMAGES`.

Using the toolkit this is not a problem, because config is generated for brand new users only. We can safely update the config seed whenever a new version of TexLive is released. 

We could even uncomment this new lines in the config seed, so new users are forced to default to the latest versions of TexLive, WDYT @ShaneKilkelly ?




## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
