### PR TITLE
Add support for `-RC` suffix in version numbers

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -29,7 +29,7 @@ function __main__() {
   local REDIS_PORT="6379"
 
   if [[ ! "$SHARELATEX_IMAGE_VERSION" \
-          =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC)?$ ]]; then
     echo "ERROR: invalid version '${SHARELATEX_IMAGE_VERSION}'"
     exit 1
   fi


### PR DESCRIPTION
## Description

Updates the RegExp check on version numbers to support testing release candidates with `-RC` suffix 



## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
