### PR TITLE
Adding version number in 'docker-compose.override.yml'

### DIFF
--- a/doc/ce-upgrading-texlive.md
+++ b/doc/ce-upgrading-texlive.md
@@ -16,9 +16,10 @@ $ docker commit sharelatex sharelatex/sharelatex:with-texlive-full
 
 Then add a `docker-compose.override.yml` file to the `config/` folder, and specify
 that the toolkit should use this new image to launch the `sharelatex` container in future:
-
+version number in `docker-compose.override.yml` MUST match the version number written in `config/version` file
 ```yml
 ---
+version: '2.2'
 services:
     sharelatex:
         image: sharelatex/sharelatex:with-texlive-full


### PR DESCRIPTION


## Description
If version number in `docker-compose.override.yml` is not present, docker-compose assumes version 1 and complains version mismatch with number given `version` file. 
If there is a better way. Maybe by updating docker-compose.base.yml or in one of the scripts in `bin/` , Please do that


## Related issues / Pull Requests
`bin/up` fails with docker-compose version mismatch error


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
