### PR TITLE
Fixed certificate lookup on bin/up

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -73,14 +73,17 @@ function __main__() {
   SHARELATEX_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$SHARELATEX_DATA_PATH")
   MONGO_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$MONGO_DATA_PATH")
   REDIS_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$REDIS_DATA_PATH")
-  if [[ -n "${TLS_PRIVATE_KEY_PATH-}" ]]; then
-    TLS_PRIVATE_KEY_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$TLS_PRIVATE_KEY_PATH")
-  fi
-  if [[ -n "${TLS_CERTIFICATE_PATH-}" ]]; then
-    TLS_CERTIFICATE_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$TLS_CERTIFICATE_PATH")
-  fi
-  if [[ -n "${NGINX_CONFIG_PATH-}" ]]; then
-    NGINX_CONFIG_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$NGINX_CONFIG_PATH")
+
+  if [[ "$NGINX_ENABLED" == "true" ]]; then
+    if [[ -n "${TLS_PRIVATE_KEY_PATH-}" ]]; then
+      TLS_PRIVATE_KEY_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$TLS_PRIVATE_KEY_PATH")
+    fi
+    if [[ -n "${TLS_CERTIFICATE_PATH-}" ]]; then
+      TLS_CERTIFICATE_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$TLS_CERTIFICATE_PATH")
+    fi
+    if [[ -n "${NGINX_CONFIG_PATH-}" ]]; then
+      NGINX_CONFIG_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$NGINX_CONFIG_PATH")
+    fi
   fi
   # Print debug info
   if [[ "${RC_DEBUG:-null}" != "null" ]]; then


### PR DESCRIPTION
## Description

Fixes certificates lookup on `bin/up`:

```
> git clone git@github.com:overleaf/toolkit.git 
> cd toolkit
> bin/init
> bin/up
realpath: config/nginx/certs/overleaf_key.pem: No such file or directory
```

Cc @mans0954 

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
