### PR TITLE
Prevent unbound var error with NGINX_ENABLED

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -75,7 +75,7 @@ function __main__() {
   REDIS_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$REDIS_DATA_PATH")
   
   # users with old config/ content might not have NGINX_ENABLED in their
-  # variables.env, this initialisation prevents an `unbound variable` error
+  # overleaf.rc, this initialisation prevents an `unbound variable` error
   if [ -z ${NGINX_ENABLED+x} ]; 
   then 
     NGINX_ENABLED="false"

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -73,6 +73,13 @@ function __main__() {
   SHARELATEX_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$SHARELATEX_DATA_PATH")
   MONGO_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$MONGO_DATA_PATH")
   REDIS_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$REDIS_DATA_PATH")
+  
+  # users with old config/ content might not have NGINX_ENABLED in their
+  # variables.env, this initialisation prevents an `unbound variable` error
+  if [ -z ${NGINX_ENABLED+x} ]; 
+  then 
+    NGINX_ENABLED="false"
+  fi
 
   if [[ "$NGINX_ENABLED" == "true" ]]; then
     if [[ -n "${TLS_PRIVATE_KEY_PATH-}" ]]; then


### PR DESCRIPTION
## Description

https://github.com/overleaf/toolkit/pull/61 fixes certificate lookup by checking `NGINX_ENABLED` value. This works just fine with new configurations, but for `overleaf.rc` files created before the TLS proxy was introduced causes  an `unbound var error` when running `bin/up` (due to `set -u`). 

In the future we need to consider backwards compatibility when adding new values to configuration.



## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
