### PR TITLE
Breaking Change: Add the new ENABLE flags for LDAP and SAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ### Added
 - `bin/upgrade` displays any changes to the changelog and prompts for
    confirmation before applying the remote changes to the local branch.
+   
+### Changed
+- Breaking change!!! LDAP and SAML features are now activated by two new
+  variables: `SHARELATEX_LDAP_ENABLE` and `SHARELATEX_SAML_ENABLE`.
+  These features will be inactive unless the appropriate line is added
+  to `config/variables.env` -- `SHARELATEX_LDAP_ENABLE=true` or
+  `SHARELATEX_SAML_ENABLE=true`
 
 ### Misc
 - Fix code linting errors in bin/ scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
    confirmation before applying the remote changes to the local branch.
    
 ### Changed
-- Breaking change!!! LDAP and SAML features are now activated by two new
+- **Breaking change**: LDAP and SAML features are now activated by two new
   variables: `SHARELATEX_LDAP_ENABLE` and `SHARELATEX_SAML_ENABLE`.
   These features will be inactive unless the appropriate line is added
   to `config/variables.env` -- `SHARELATEX_LDAP_ENABLE=true` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
   variables: `SHARELATEX_LDAP_ENABLE` and `SHARELATEX_SAML_ENABLE`.
   These features will be inactive unless the appropriate line is added
   to `config/variables.env` -- `SHARELATEX_LDAP_ENABLE=true` or
-  `SHARELATEX_SAML_ENABLE=true`
+  `SHARELATEX_SAML_ENABLE=true`. The `bin/upgrade` script will try to add the
+  appropriate lines automatically, but we recommend checking the
+  `config/variables.env` file manually before starting the services.
 
 ### Misc
 - Fix code linting errors in bin/ scripts

--- a/bin/_vendor/semver-compare
+++ b/bin/_vendor/semver-compare
@@ -1,0 +1,345 @@
+#! /usr/bin/env sh
+
+# Vendored from https://github.com/Ariel-Rodriguez/sh-semversion-2
+
+# POSIX SH portable semver 2.0 comparition tool.
+
+# This bash script compares pre-releases alphabetically as well (number < lowerCaseLetter < upperCaseLetter)
+#
+# returns 1 when A greater than B
+# returns 0 when A equals B
+# returns -1 when A lower than B
+#
+# Usage
+# ./semver-compare 1.0.0-rc.0.a+metadata v1.0.0-rc.0+metadata
+# --> 1
+#
+
+# This software was built with the help of the following sources:
+# https://stackoverflow.com/a/58067270
+# https://www.unix.com/man-page/posix/1posix/cut/
+# https://stackoverflow.com/questions/51052475/how-to-iterate-over-the-characters-of-a-string-in-a-posix-shell-script
+
+set -eu
+
+debug() {
+  if [ "$debug" = "debug" ]; then printf "DEBUG: %s$1 \n"; fi
+}
+
+# params char
+# returns Integer
+ord() {
+  printf '%d' "'$1"
+}
+
+
+isNumber() {
+  string=$1
+  char=""
+  while true; do
+    substract="${string#?}"    # All but the first character of the string
+    char="${string%"$substract"}"    # Remove $rest, and you're left with the first character
+    string="$substract"
+    # no more chars to compare then success
+    if [ -z "$char" ]; then
+      printf "true"
+      return 1
+    fi
+    # break if some of the chars is not a number
+    if [ "$(ord "$char")" -lt 48 ] || [ "$(ord "$char")" -gt 57 ]; then
+      printf "false"
+      return 0
+    fi
+  done
+}
+
+# params string {String}, Index {Number}
+# returns char
+getChar() {
+  string=$1
+  index=$2
+  cursor=-1
+  char=""
+  while [ "$cursor" != "$index" ]; do
+    substract="${string#?}"    # All but the first character of the string
+    char="${string%"$substract"}"    # Remove $rest, and you're left with the first character
+    string="$substract"
+    cursor=$((cursor + 1))
+  done
+  printf "%s$char"
+}
+
+outcome() {
+  result=$1
+  printf "%s$result\n"
+}
+
+
+compareNumber() {
+  if [ -z "$1" ] && [ -z "$2" ]; then
+    printf "%s" "0"
+    return
+  fi
+
+  [ $(($2 - $1)) -gt 0 ] && printf "%s" "-1"
+  [ $(($2 - $1)) -lt 0 ] && printf "1"
+  [ $(($2 - $1)) = 0 ] && printf "0"
+}
+
+compareString() {
+  result=false
+  index=0
+  while true
+  do
+    a=$(getChar "$1" $index)
+    b=$(getChar "$2" $index)
+
+    if [ -z "$a" ] && [ -z "$b" ]
+    then
+      printf "0"
+      return
+    fi
+
+    ord_a=$(ord "$a")
+    ord_b=$(ord "$b")
+
+    if [ "$(compareNumber "$ord_a" "$ord_b")" != "0" ]; then
+      printf "%s" "$(compareNumber "$ord_a" "$ord_b")"
+      return
+    fi
+
+    index=$((index + 1))
+  done
+}
+
+includesString() {
+  string="$1"
+  substring="$2"
+  if [ "${string#*$substring}" != "$string" ]
+  then
+    printf "1"
+    return 1    # $substring is in $string
+  fi
+  printf "0"
+  return 0    # $substring is not in $string
+}
+
+removeLeadingV() {
+  printf "%s${1#v}"
+}
+
+# https://github.com/Ariel-Rodriguez/sh-semversion-2/pull/2
+# Spec #2 https://semver.org/#spec-item-2
+# MUST NOT contain leading zeroes
+normalizeZero() {
+  next=$(printf %s "${1#0}")
+  if [ -z "$next" ]; then
+    printf %s "$1"
+  fi
+  printf %s "$next"
+}
+
+semver_compare() {
+  firstParam=$1 #1.2.4-alpha.beta+METADATA
+  secondParam=$2 #1.2.4-alpha.beta.2+METADATA
+  debug=${3:-1}
+  verbose=${4:-1}
+
+  [ "$verbose" = "verbose" ] && set -x
+
+  version_a=$(printf %s "$firstParam" | cut -d'+' -f 1)
+  version_a=$(removeLeadingV "$version_a")
+  version_b=$(printf %s "$secondParam" | cut -d'+' -f 1)
+  version_b=$(removeLeadingV "$version_b")
+
+  a_major=$(printf %s "$version_a" | cut -d'.' -f 1)
+  a_minor=$(printf %s "$version_a" | cut -d'.' -f 2)
+  a_patch=$(printf %s "$version_a" | cut -d'.' -f 3 | cut -d'-' -f 1)
+  a_pre=""
+  if [ "$(includesString "$version_a" -)" = 1 ]; then
+    a_pre=$(printf %s"${version_a#$a_major.$a_minor.$a_patch-}")
+  fi
+
+  b_major=$(printf %s "$version_b" | cut -d'.' -f 1)
+  b_minor=$(printf %s "$version_b" | cut -d'.' -f 2)
+  b_patch=$(printf %s "$version_b" | cut -d'.' -f 3 | cut -d'-' -f 1)
+  b_pre=""
+  if [ "$(includesString "$version_b" -)" = 1 ]; then
+    b_pre=$(printf %s"${version_b#$b_major.$b_minor.$b_patch-}")
+  fi
+
+  a_major=$(normalizeZero "$a_major")
+  a_minor=$(normalizeZero "$a_minor")
+  a_patch=$(normalizeZero "$a_patch")
+  b_major=$(normalizeZero "$b_major")
+  b_minor=$(normalizeZero "$b_minor")
+  b_patch=$(normalizeZero "$b_patch")
+
+  unit_types="MAJOR MINOR PATCH"
+  a_normalized="$a_major $a_minor $a_patch"
+  b_normalized="$b_major $b_minor $b_patch"
+
+  debug "Detected: $a_major $a_minor $a_patch identifiers: $a_pre"
+  debug "Detected: $b_major $b_minor $b_patch identifiers: $b_pre"
+
+  #####
+  #
+  # Find difference between Major Minor or Patch
+  #
+
+  cursor=1
+  while [ "$cursor" -lt 4 ]
+  do
+    a=$(printf %s "$a_normalized" | cut -d' ' -f $cursor)
+    b=$(printf %s "$b_normalized" | cut -d' ' -f $cursor)
+    if [ "$a" != "$b" ]
+    then
+      debug "$(printf %s "$unit_types" | cut -d' ' -f $cursor) is different"
+      outcome "$(compareNumber "$a" "$b")"
+      return
+    fi;
+    debug "$(printf "%s" "$unit_types" | cut -d' ' -f $cursor) are equal"
+    cursor=$((cursor + 1))
+  done
+
+  #####
+  #
+  # Find difference between pre release identifiers
+  #
+
+  if [ -z "$a_pre" ] && [ -z "$b_pre" ]; then
+    debug "Because both are equals"
+    outcome "0"
+    return
+  fi
+
+  # Spec 11.3 a pre-release version has lower precedence than a normal version:
+  # Example: 1.0.0-alpha < 1.0.0.
+
+  if [ -z "$a_pre" ]; then
+    debug "Because a pre-release version has lower precedence than a normal version"
+    outcome "1"
+    return
+  fi
+
+  if [ -z "$b_pre" ]; then
+    debug "Because a pre-release version has lower precedence than a normal version"
+    outcome "-1"
+    return
+  fi
+
+
+  isSingleIdentifier() {
+    substract="${2#?}"
+    if [ "${1%"$2"}" = "" ]; then
+      printf "true"
+      return 1;
+    fi
+    return 0
+  }
+
+  cursor=1
+  while [ $cursor -lt 4 ]
+  do
+    a=$(printf %s "$a_pre" | cut -d'.' -f $cursor)
+    b=$(printf %s "$b_pre" | cut -d'.' -f $cursor)
+
+    debug "Comparing identifier $a with $b"
+
+    # Exit when there is nothing else to compare.
+    # Most likely because they are equals
+    if [ -z "$a" ] && [ -z "$b" ]
+    then
+      debug "are equals"
+      outcome "0"
+      return
+    fi;
+
+    # Spec #11 https://semver.org/#spec-item-11
+    # Precedence for two pre-release versions with the same major, minor, and patch version
+    # MUST be determined by comparing each dot separated identifier from left to right until a difference is found
+
+    # Spec 11.4.4: A larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal.
+    if [ -n "$a" ] && [ -z "$b" ]; then
+      # When A is larger than B
+      debug "Because A has more pre-identifiers"
+      outcome "1"
+      return
+    fi
+
+    # When A is shorter than B
+    if [ -z "$a" ] && [ -n "$b" ]; then
+      debug "Because B has more pre-identifiers"
+      outcome "-1"
+      return
+    fi
+
+    # Spec #11.4.1
+    # Identifiers consisting of only digits are compared numerically.
+    if [ "$(isNumber "$a")" = "true" ] || [ "$(isNumber "$b")" = "true" ]; then
+
+      # if both identifiers are numbers, then compare and proceed
+      if [ "$(isNumber "$a")" = "true" ] && [ "$(isNumber "$b")" = "true" ]; then
+        if [ "$(compareNumber "$a" "$b")" != "0" ]; then
+          debug "Number is not equal $(compareNumber "$a" "$b")"
+          outcome "$(compareNumber "$a" "$b")"
+          return
+        fi
+      fi
+
+      # Spec 11.4.3
+      if [ "$(isNumber "$a")" = "false" ]; then
+        debug "Because Numeric identifiers always have lower precedence than non-numeric identifiers."
+        outcome "1"
+        return
+      fi
+
+      if [ "$(isNumber "$b")" = "false" ]; then
+        debug "Because Numeric identifiers always have lower precedence than non-numeric identifiers."
+        outcome "-1"
+        return
+      fi
+    else
+      # Spec 11.4.2
+      # Identifiers with letters or hyphens are compared lexically in ASCII sort order.
+      if [ "$(compareString "$a" "$b")" != "0" ]; then
+        debug "cardinal is not equal $(compareString a b)"
+        outcome "$(compareString "$a" "$b")"
+        return
+      fi
+    fi
+
+    # Edge case when there is single identifier exaple: x.y.z-beta
+    if [ "$cursor" = 1 ]; then
+
+      # When both versions are single return equals
+      if [ -n "$(isSingleIdentifier "$b_pre" "$b")" ] && [ -n "$(isSingleIdentifier "$a_pre" "$a")" ]; then
+        debug "Because both have single identifier"
+        outcome "0"
+        return
+      fi
+
+      # Return greater when has more identifiers
+      # Spec 11.4.4: A larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal.
+
+      # When A is larger than B
+      if [ -n "$(isSingleIdentifier "$b_pre" "$b")" ] && [ -z "$(isSingleIdentifier "$a_pre" "$a")" ]; then
+        debug "Because of single identifier, A has more pre-identifiers"
+        outcome "1"
+        return
+      fi
+
+      # When A is shorter than B
+      if [ -z "$(isSingleIdentifier "$b_pre" "$b")" ] && [ -n "$(isSingleIdentifier "$a_pre" "$a")" ]; then
+        debug "Because of single identifier, B has more pre-identifiers"
+        outcome "-1"
+        return
+      fi
+    fi
+
+    # Proceed to the next identifier because previous comparition was equal.
+    cursor=$((cursor + 1))
+  done
+}
+
+printf "%s$(semver_compare "$@")\n"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -10,10 +10,34 @@ command -v realpath >/dev/null 2>&1 || realpath() {
 SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 TOOLKIT_ROOT="$(realpath "$SCRIPT_DIR/..")"
+VENDOR="$TOOLKIT_ROOT/bin/_vendor"
 if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
   echo "ERROR: could not find root of overleaf-toolkit project (inferred project root as '$TOOLKIT_ROOT')"
   exit 1
 fi
+
+function _line_in_variables() {
+  grep -qE "$1" "$TOOLKIT_ROOT/config/variables.env"
+}
+
+function _migrate_update_ldap_saml_flags() {
+  if _line_in_variables "^SHARELATEX_LDAP_URL=['\"]?.*['\"]?" \
+    && ! _line_in_variables "SHARELATEX_LDAP_ENABLE="
+  then
+    echo "Updating LDAP settings in config/variables.env"
+    sed -E -i.bak "/^SHARELATEX_LDAP_URL=['\"]?.*['\"]?/ i\
+      SHARELATEX_LDAP_ENABLE=true  # introduced in 3.0" \
+      "$TOOLKIT_ROOT/config/variables.env"
+  fi
+  if _line_in_variables "^SHARELATEX_SAML_ENTRYPOINT=['\"]?.*['\"]?" \
+    && ! _line_in_variables "SHARELATEX_SAML_ENABLE="
+  then
+    echo "Updating SAML settings in config/variables.env"
+    sed -E -i.bak "/^SHARELATEX_SAML_ENTRYPOINT=['\"]?.*['\"]?/ i\
+      SHARELATEX_SAML_ENABLE=true  # introduced in 3.0" \
+      "$TOOLKIT_ROOT/config/variables.env"
+  fi
+}
 
 function usage() {
   echo "Usage: bin/upgrade"
@@ -143,6 +167,16 @@ function handle_image_upgrade() {
   cp "$TOOLKIT_ROOT/config/version" "$TOOLKIT_ROOT/config/__old-version"
   echo "Over-writing config/version with $seed_image_version"
   cp "$TOOLKIT_ROOT/lib/config-seed/version" "$TOOLKIT_ROOT/config/version"
+
+  ## Check if we need to run upgrade functions
+  local old_version
+  local new_version
+  old_version="$(cat "$TOOLKIT_ROOT/config/__old-version")"
+  new_version="$(cat "$TOOLKIT_ROOT/config/version")"
+  if [[ "$("$VENDOR/semver-compare" "$old_version" '3.0.0')" == "-1" ]] && \
+     [[ "$("$VENDOR/semver-compare" "$new_version" '3.0.0')" == "1" ]]; then
+    _migrate_update_ldap_saml_flags
+  fi
 
   ## Maybe offer to start services again
   if [[ "${services_stopped:-null}" == "true" ]]; then

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -26,7 +26,7 @@ function _migrate_update_ldap_saml_flags() {
   then
     echo "Updating LDAP settings in config/variables.env"
     sed -E -i.bak "/^SHARELATEX_LDAP_URL=['\"]?.*['\"]?/ i\
-      SHARELATEX_LDAP_ENABLE=true  # introduced in 3.0" \
+      SHARELATEX_LDAP_ENABLE=true  # Introduced in 3.0, this line added automatically" \
       "$TOOLKIT_ROOT/config/variables.env"
   fi
   if _line_in_variables "^SHARELATEX_SAML_ENTRYPOINT=['\"]?.*['\"]?" \
@@ -34,8 +34,19 @@ function _migrate_update_ldap_saml_flags() {
   then
     echo "Updating SAML settings in config/variables.env"
     sed -E -i.bak "/^SHARELATEX_SAML_ENTRYPOINT=['\"]?.*['\"]?/ i\
-      SHARELATEX_SAML_ENABLE=true  # introduced in 3.0" \
+      SHARELATEX_SAML_ENABLE=true  # Introduced in 3.0, this line added automatically" \
       "$TOOLKIT_ROOT/config/variables.env"
+  fi
+}
+
+function _maybe_config_migrations() {
+  local old_version="$1"
+  local new_version="$2"
+  ## LDAP and SAML flags
+  if [[ "$("$VENDOR/semver-compare" "$old_version" 3.0.0)" == "-1" ]] && \
+     [[ "$("$VENDOR/semver-compare" "$new_version" 3.0.0)" != "-1" ]]; then
+    echo "Checking if LDAP/SAML config needs to be updated"
+    _migrate_update_ldap_saml_flags
   fi
 }
 
@@ -168,15 +179,13 @@ function handle_image_upgrade() {
   echo "Over-writing config/version with $seed_image_version"
   cp "$TOOLKIT_ROOT/lib/config-seed/version" "$TOOLKIT_ROOT/config/version"
 
-  ## Check if we need to run upgrade functions
   local old_version
   local new_version
   old_version="$(cat "$TOOLKIT_ROOT/config/__old-version")"
   new_version="$(cat "$TOOLKIT_ROOT/config/version")"
-  if [[ "$("$VENDOR/semver-compare" "$old_version" '3.0.0')" == "-1" ]] && \
-     [[ "$("$VENDOR/semver-compare" "$new_version" '3.0.0')" == "1" ]]; then
-    _migrate_update_ldap_saml_flags
-  fi
+
+  ## Check if we need to run upgrade functions
+  _maybe_config_migrations "$old_version" "$new_version"
 
   ## Maybe offer to start services again
   if [[ "${services_stopped:-null}" == "true" ]]; then

--- a/doc/ldap.md
+++ b/doc/ldap.md
@@ -17,6 +17,7 @@ At Overleaf, we test the LDAP integration against a [test openldap server](https
 ```
 # added to variables.env
 
+SHARELATEX_LDAP_ENABLE=true
 SHARELATEX_LDAP_URL=ldap://ldap:389
 SHARELATEX_LDAP_SEARCH_BASE=ou=people,dc=planetexpress,dc=com
 SHARELATEX_LDAP_SEARCH_FILTER=(uid={{username}})

--- a/doc/saml.md
+++ b/doc/saml.md
@@ -13,6 +13,7 @@ At Overleaf, we test the SAML integration against a SAML test server. The follow
 ```
 # added to variables.env
 
+SHARELATEX_SAML_ENABLE=true
 SHARELATEX_SAML_ENTRYPOINT=http://localhost:8081/simplesaml/saml2/idp/SSOService.php
 SHARELATEX_SAML_CALLBACK_URL=http://saml/saml/callback
 SHARELATEX_SAML_ISSUER=sharelatex-test-saml

--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -48,6 +48,7 @@ TEXMFVAR=/var/lib/sharelatex/tmp/texmf-var
 ## Server Pro ##
 ################
 
+# SHARELATEX_LDAP_ENABLE=true
 # SHARELATEX_LDAP_URL=ldap://ldap:389
 # SHARELATEX_LDAP_SEARCH_BASE=ou=people,dc=planetexpress,dc=com
 # SHARELATEX_LDAP_SEARCH_FILTER=(uid={{username}})


### PR DESCRIPTION
## Description

In https://github.com/overleaf/web-internal/pull/4332, we added two new environment flags, `SHARELATEX_LDAP_ENABLE` and `SHARELATEX_SAML_ENABLE`, to gain more explicit control over how the LDAP and SAML features are activated. This helped with testing those modules in the same test framework.

This PR adds these new flags to the toolkit documentation, and to the default `variables.env` file, plus a note in the changelog, informing users that they will need to add these lines to their own variables in `config/variables.env`.

We also update the `bin/upgrade` script to automatically add the appropriate variable to the users `variables.env` file, if they are already using SAML or LDAP in their configuration. (and to help with this, we vendor a script from [here](https://github.com/Ariel-Rodriguez/sh-semversion-2/blob/main/semver2.sh) to compare semver strings)


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
- Related to changes in https://github.com/overleaf/web-internal/pull/4332
- Part of epic https://github.com/overleaf/issues/issues/3229


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
