### PR TITLE
Remove `linked_url` from `ENABLED_LINKED_FILE_TYPES` config seed

### DIFF
--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -1,6 +1,6 @@
 SHARELATEX_APP_NAME=Our Overleaf Instance
 
-ENABLED_LINKED_FILE_TYPES=url,project_file
+ENABLED_LINKED_FILE_TYPES=project_file,project_output_file
 
 # Enables Thumbnail generation using ImageMagick
 ENABLE_CONVERSIONS=true


### PR DESCRIPTION
Also added `project_output_file` as default. 

This change doesn't break backwards compatibility.



## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
