### PR TITLE
[config-seed] remove spurious quotes from values

### DIFF
--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -62,7 +62,7 @@ EXTERNAL_AUTH=none
 # SHARELATEX_TEMPLATES_USER_ID=578773160210479700917ee5
 # SHARELATEX_NEW_PROJECT_TEMPLATE_LINKS=[{"name":"All Templates","url":"/templates/all"}]
 
-TEX_LIVE_DOCKER_IMAGE="quay.io/sharelatex/texlive-full:2020.1"
-ALL_TEX_LIVE_DOCKER_IMAGES="quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1"
+TEX_LIVE_DOCKER_IMAGE=quay.io/sharelatex/texlive-full:2020.1
+ALL_TEX_LIVE_DOCKER_IMAGES=quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1
 
-# SHARELATEX_PROXY_LEARN="true"
+# SHARELATEX_PROXY_LEARN=true


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

For https://github.com/overleaf/toolkit/pull/58#issuecomment-906734440

This PR is dropping spurious quotes from the config seed. 

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

For https://github.com/overleaf/toolkit/pull/58#issuecomment-906734440

## Manual testing performed

- clone toolkit from this branch
- enable server-pro and sibling compiles
- start server-pro
- after ~60s, see login to quay and pull of two texlive images, they both succeed
- un-comment `SHARELATEX_PROXY_LEARN` variable
- http://localhost/learn/latex/Learn_LaTeX_in_30_minutes displays wiki page

<details>

```
sharelatex    | quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1 need installing, logging in to quay.io
sharelatex    | Using sandboxed compiles with sibling containers
sharelatex    | Going to sleep forever without starting docker daemon
mongo         | 2021-08-27T09:58:26.847+0000 I NETWORK  [listener] connection accepted from 127.0.0.1:57098 #20 (9 connections now open)
...
sharelatex    | 
sharelatex    | Login Succeeded
sharelatex    | quay.io/sharelatex/texlive-full:2020.1 download started (may take some time)
sharelatex    | 2020.1: Pulling from sharelatex/texlive-full
sharelatex    | 692c352adcf2: Already exists
sharelatex    | 97058a342707: Already exists
sharelatex    | 2821b8e766f4: Already exists
...
sharelatex    | 7bad57aaefb1: Pulling fs layer
sharelatex    | e246c9cdf679: Pulling fs layer
sharelatex    | e246c9cdf679: Verifying Checksum
sharelatex    | e246c9cdf679: Download complete
sharelatex    | 7bad57aaefb1: Verifying Checksum
sharelatex    | 7bad57aaefb1: Download complete
sharelatex    | 2b1764314b52: Verifying Checksum
sharelatex    | 2b1764314b52: Download complete
mongo         | 2021-08-27T09:58:36.997+0000 I NETWORK  [listener] connection accepted from 127.0.0.1:57134 #21 (9 connections now open)
...
sharelatex    | 2b1764314b52: Pull complete
sharelatex    | 7bad57aaefb1: Pull complete
sharelatex    | e246c9cdf679: Pull complete
sharelatex    | Digest: sha256:70c66a7365d97942038af32e5e72b3bd58ce867bd1688aaa45dcb20cd9aab30a
sharelatex    | Status: Downloaded newer image for quay.io/sharelatex/texlive-full:2020.1
sharelatex    | quay.io/sharelatex/texlive-full:2020.1
sharelatex    | quay.io/sharelatex/texlive-full:2020.1 download finished
sharelatex    | quay.io/sharelatex/texlive-full:2019.1 download started (may take some time)
sharelatex    | 2019.1: Pulling from sharelatex/texlive-full
sharelatex    | 5b7339215d1d: Already exists
sharelatex    | 14ca88e9f672: Already exists
sharelatex    | a31c3b1caad4: Already exists
...
sharelatex    | 9ee3b711fd7d: Already exists
sharelatex    | 34e40ebf95f0: Already exists
sharelatex    | d7334c2d044e: Already exists
sharelatex    | 66397b0d8473: Already exists
sharelatex    | dff8cfa999a4: Pulling fs layer
sharelatex    | dff8cfa999a4: Download complete
sharelatex    | dff8cfa999a4: Pull complete
sharelatex    | Digest: sha256:c4491c9d4c55a8e3febc159557ef37169c40a99969700e2eae97de639437d749
sharelatex    | Status: Downloaded newer image for quay.io/sharelatex/texlive-full:2019.1
sharelatex    | quay.io/sharelatex/texlive-full:2019.1
sharelatex    | quay.io/sharelatex/texlive-full:2019.1 download finished
```
</details>

## Who needs to know?

@pdgessler 