### PR TITLE
Csh listen ip

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -113,12 +113,16 @@ function __main__() {
   export MONGO_URL
   export NGINX_CONFIG_PATH
   export NGINX_IMAGE
+  export NGINX_HTTP_PORT
+  export NGINX_HTTP_LISTEN_IP
+  export NGINX_TLS_LISTEN_IP
   export REDIS_DATA_PATH
   export REDIS_HOST
   export REDIS_IMAGE
   export REDIS_PORT
   export SHARELATEX_DATA_PATH
   export SHARELATEX_PORT
+  export SHARELATEX_LISTEN_IP
   export TLS_CERTIFICATE_PATH
   export TLS_PORT
   export TLS_PRIVATE_KEY_PATH

--- a/doc/overleaf-rc.md
+++ b/doc/overleaf-rc.md
@@ -22,10 +22,17 @@ Sets the path to the directory that will be mounted into the main `sharelatex` c
 
 - Default: data/sharelatex
 
+### `SHARELATEX_LISTEN_IP`
+
+Sets the host IP address(es) that the container will bind to. For example, if this is set to `0.0.0.0`, then the web interface will be available on any host IP address.
+
+Setting `SHARELATEX_LISTEN_IP` to either `0.0.0.0` or the external IP of your host will typically cause errors when used in conjunction with the [TLS Proxy](tls-proxy.md).
+
+- Default: 127.0.0.1
 
 ### `SHARELATEX_PORT`
 
-Sets the host port that the container will bind to. For example, if this is set to `8099`, then the web interface will be available on `http://localhost:8099`.
+Sets the host port that the container will bind to. For example, if this is set to `8099` and `SHARELATEX_LISTEN_IP` is set to `127.0.0.1`, then the web interface will be available on `http://localhost:8099`.
 
 When used in conjunction with the [TLS Proxy](tls-proxy.md), the `proxy_pass` port in [nginx.conf](config/nginx/nginx.conf) also needs to be changed.
 
@@ -133,8 +140,24 @@ Path to the public certificate to use for the [TLS Proxy](tls-proxy.md).
 
 - Default: config/nginx/certs/overleaf_certificate.pem
 
+### `NGINX_TLS_LISTEN_IP`
+
+Sets the host IP address(es) that the [TLS Proxy](tls-proxy.md) container will bind to for https. For example, if this is set to `0.0.0.0` then the https web interface will be available on any host IP address.
+
+Typically this should be set to the external IP of your host.
+
+- Default: 127.0.1.1
+
 ### `TLS_PORT`
 
-Sets the host port that the [TLS Proxy](tls-proxy.md) container will bind to. For example, if this is set to `8443`, then the https web interface will be available on `https://localhost:8443`.
+Sets the host port that the [TLS Proxy](tls-proxy.md) container will bind to for https. For example, if this is set to `8443`, then the https web interface will be available on `https://localhost:8443`.
 
 - Default: 443
+
+### `NGINX_HTTP_LISTEN_IP`
+
+Sets the host IP address(es) that the [TLS Proxy](tls-proxy.md) container will bind to for http redirect. For example, if this is set to `127.0.1.1` then http connections to `127.0.1.1` will be redirected to the https web interface.
+
+Typically this should be set to the external IP of your host. Do not set it to `0.0.0.0` as this will typically cause a conflict with `SHARELATEX_LISTEN_IP`.
+
+- Default: 127.0.1.1

--- a/doc/tls-proxy.md
+++ b/doc/tls-proxy.md
@@ -17,6 +17,10 @@ Add the following section to your `config/overleaf.rc` file if it is not there a
 # See documentation in doc/tls-proxy.md
 NGINX_ENABLED=false
 NGINX_CONFIG_PATH=config/nginx/nginx.conf
+NGINX_HTTP_PORT=80
+# Replace these IP addresses with the external IP address of your host
+NGINX_HTTP_LISTEN_IP=127.0.1.1 
+NGINX_TLS_LISTEN_IP=127.0.1.1
 TLS_PRIVATE_KEY_PATH=config/nginx/certs/overleaf_key.pem
 TLS_CERTIFICATE_PATH=config/nginx/certs/overleaf_certificate.pem
 TLS_PORT=443
@@ -26,4 +30,6 @@ TLS_PORT=443
 
 When the [SHARELATEX_PORT](overleaf-rc.md#sharelatex_port) variable is set, the port in the `proxy_pass` statement in `nginx.conf` needs to be changed to match.
 
-By default the https web interface will be available on `https://localhost:443`. The port can be changed via the `TLS_PORT` variable. 
+By default the https web interface will be available on `https://127.0.1.1:443`. Connections to `http://127.0.1.1:80` will be redirected to `https://127.0.1.1:443`. To change the IP address that NGINX listens on, set the `NGINX_HTTP_LISTEN_IP` and `NGINX_TLS_LISTEN_IP` variables. The ports can be changed via the `NGINX_HTTP_PORT` and `TLS_PORT` variables.
+
+If NGINX fails to start with the error message `Error starting userland proxy: listen tcp4 ... bind: address already in use` ensure that `SHARELATEX_LISTEN_IP:SHARELATEX_PORT` does not overlap with `NGINX_HTTP_LISTEN_IP:NGINX_HTTP_PORT`.

--- a/lib/config-seed/nginx.conf
+++ b/lib/config-seed/nginx.conf
@@ -1,6 +1,14 @@
 events {}
 
 http {
+
+    server {
+        listen 80 default_server;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
+
     server {
         listen 443 ssl;
 

--- a/lib/config-seed/overleaf.rc
+++ b/lib/config-seed/overleaf.rc
@@ -5,6 +5,7 @@ PROJECT_NAME=overleaf
 # Sharelatex container
 SHARELATEX_DATA_PATH=data/sharelatex
 SERVER_PRO=false
+SHARELATEX_LISTEN_IP=127.0.0.1
 SHARELATEX_PORT=80
 
 # Sibling Containers
@@ -23,6 +24,10 @@ REDIS_DATA_PATH=data/redis
 # See documentation in doc/tls-proxy.md
 NGINX_ENABLED=false
 NGINX_CONFIG_PATH=config/nginx/nginx.conf
+NGINX_HTTP_PORT=80
+# Replace these IP addresses with the external IP address of your host
+NGINX_HTTP_LISTEN_IP=127.0.1.1 
+NGINX_TLS_LISTEN_IP=127.0.1.1
 TLS_PRIVATE_KEY_PATH=config/nginx/certs/overleaf_key.pem
 TLS_CERTIFICATE_PATH=config/nginx/certs/overleaf_certificate.pem
 TLS_PORT=443

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -9,7 +9,7 @@ services:
         volumes:
             - "${SHARELATEX_DATA_PATH}:/var/lib/sharelatex"
         ports:
-            - "${SHARELATEX_PORT:-80}:80"
+            - "${SHARELATEX_LISTEN_IP:-127.0.0.1}:${SHARELATEX_PORT:-80}:80"
         environment:
           SHARELATEX_MONGO_URL: "${MONGO_URL}"
           SHARELATEX_REDIS_HOST: "${REDIS_HOST}"

--- a/lib/docker-compose.nginx.yml
+++ b/lib/docker-compose.nginx.yml
@@ -5,7 +5,8 @@ services:
   nginx:
     image: "${NGINX_IMAGE}"
     ports:
-      - "127.0.0.1:${TLS_PORT:-443}:443"
+      - "${NGINX_TLS_LISTEN_IP:-0.0.0.0}:${TLS_PORT:-443}:443"
+      - "${NGINX_HTTP_LISTEN_IP:-127.0.1.1}:${SHARELATEX_PORT:-80}:80"
     volumes:
       - "${TLS_PRIVATE_KEY_PATH}:/certs/nginx_key.pem:ro"
       - "${TLS_CERTIFICATE_PATH}:/certs/nginx_certificate.pem:ro"


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

This PR adds http to https redirect to the NGINX config. It also provides variables to configure the IP address and ports that NGINX listens to for http and https connections.

Previously the docker-compose files hardcoded the `sharelatex` container to listen on 0.0.0.0. In order to avoid a conflict with the NGINX http redirect when both are using the default port 80, I also introduced a `SHARELATEX_LISTEN_IP` variable, defualting to `127.0.0.1` instead of `0.0.0.0` - a change in the default behaviour.

It might be a bit more consistent if `TLS_PORT` was `NGINX_HTTPS_PORT` and `NGINX_TLS_LISTEN_IP` was `NGINX_HTTPS_LISTEN_IP` - but the `TLS_PORT` variable already exists, and I'm not sure if we want to rename it?

This PR was inspired by https://github.com/overleaf/toolkit/pull/76

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

https://github.com/overleaf/toolkit/pull/76

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
