### PR TITLE
[config-seed] variables: hide texlive image list by default

### DIFF
--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -62,7 +62,7 @@ EXTERNAL_AUTH=none
 # SHARELATEX_TEMPLATES_USER_ID=578773160210479700917ee5
 # SHARELATEX_NEW_PROJECT_TEMPLATE_LINKS=[{"name":"All Templates","url":"/templates/all"}]
 
-TEX_LIVE_DOCKER_IMAGE=quay.io/sharelatex/texlive-full:2020.1
-ALL_TEX_LIVE_DOCKER_IMAGES=quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1
+# TEX_LIVE_DOCKER_IMAGE=quay.io/sharelatex/texlive-full:2020.1
+# ALL_TEX_LIVE_DOCKER_IMAGES=quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1
 
 # SHARELATEX_PROXY_LEARN=true

--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -62,7 +62,7 @@ EXTERNAL_AUTH=none
 # SHARELATEX_TEMPLATES_USER_ID=578773160210479700917ee5
 # SHARELATEX_NEW_PROJECT_TEMPLATE_LINKS=[{"name":"All Templates","url":"/templates/all"}]
 
-# TEX_LIVE_DOCKER_IMAGE=quay.io/sharelatex/texlive-full:2020.1
-# ALL_TEX_LIVE_DOCKER_IMAGES=quay.io/sharelatex/texlive-full:2020.1,quay.io/sharelatex/texlive-full:2019.1
+# TEX_LIVE_DOCKER_IMAGE=quay.io/sharelatex/texlive-full:2021.1
+# ALL_TEX_LIVE_DOCKER_IMAGES=quay.io/sharelatex/texlive-full:2021.1,quay.io/sharelatex/texlive-full:2020.1
 
 # SHARELATEX_PROXY_LEARN=true


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

For https://digital-science.slack.com/archives/C20TZCMMF/p1643280721258100
Closes https://github.com/overleaf/overleaf/issues/989

This PR is hiding the texlive image list by default. It is of interest for Server Pro only.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

For https://digital-science.slack.com/archives/C20TZCMMF/p1643280721258100
Closes https://github.com/overleaf/overleaf/issues/989

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
