### PR TITLE
Fix links in documentation

### DIFF
--- a/doc/overleaf-rc.md
+++ b/doc/overleaf-rc.md
@@ -50,7 +50,7 @@ When set to `true`, tells the toolkit to use the Server Pro image (`quay.io/shar
 
 When set to `true`, tells the toolkit to use the "Sibling Containers" technique
 for compiling projects in separate sandboxes, using a separate docker container for
-each project. See (the legacy documentation on Sandboxed Compiles)[https://github.com/sharelatex/sharelatex/wiki/Server-Pro:-sandboxed-compiles] for more information.
+each project. See [the legacy documentation on Sandboxed Compiles](https://github.com/sharelatex/sharelatex/wiki/Server-Pro:-sandboxed-compiles) for more information.
 
 Requires `SERVER_PRO=true`
 

--- a/doc/quick-start-guide.md
+++ b/doc/quick-start-guide.md
@@ -90,10 +90,10 @@ If you press `CTRL-C` at the terminal, the services will shut down. You can star
 
 ## Create the first admin account
 
-In a browser, open `http://localhost/launchpad`. You should see a form with email and password fields.
+In a browser, open <http://localhost/launchpad>. You should see a form with email and password fields.
 Fill these in with the credentials you want to use as the admin account, then click "Register".
 
-Then click the link to go to the login page (`http://localhost/login`). Enter the credentials.
+Then click the link to go to the login page (<http://localhost/login>). Enter the credentials.
 Once you are logged in, you will be taken to a welcome page.
 
 Click the green button at the bottom of the page to start using Overleaf. 
@@ -101,7 +101,7 @@ Click the green button at the bottom of the page to start using Overleaf.
 
 ## Create your first project
 
-On the `http://localhost/project` page, you will see a button prompting you to create your first
+On the <http://localhost/project> page, you will see a button prompting you to create your first
 project. Click the button and follow the instructions.
 
 You should then be taken to the new project, where you will see a text editor and a PDF preview.


### PR DESCRIPTION
## Description

* Fix a link in the `overleaf.rc` documentation.
* Convert some URLs to links in the Quick Start guide. 

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
