### PR TITLE
Change suggested directory name from `overleaf` to `overleaf-toolkit` in the Quick Start Guide

### DIFF
--- a/doc/quick-start-guide.md
+++ b/doc/quick-start-guide.md
@@ -17,13 +17,13 @@ are available on your system.
 First, let's clone this git repository to your machine:
 
 ```sh
-$ git clone https://github.com/overleaf/toolkit.git ./overleaf
+$ git clone https://github.com/overleaf/toolkit.git ./overleaf-toolkit
 ```
 
 Next let's move into this directory:
 
 ```sh
-$ cd ./overleaf
+$ cd ./overleaf-toolkit
 ```
 
 For the rest of this guide, we will assume that you will run all subsequent commands from this directory.


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

`overleaf` is the default directory name for the https://github.com/overleaf/overleaf repository when cloned, it would be better if the documentation suggests a different directory name for toolkit so they won't conflict when the toolkit repositor is cloned in the same parent directory as the overleaf community edition.

It won't happen a lot, since toolkit doesn't require a clone of overleaf community edition repo. But it can happen especially to users that clone the community edition first before toolkit, while simply following the toolkit quick start guide.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
