### PR TITLE
Add docs and default config for `SHARELATEX_LISTEN_IP`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## TBD
+## 2022-08-16
+### Added
+- Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `3.2.0`.
+- Updated Mongo version from 4.2 to 4.4. Documentation on Mongo updates can be found [here](https://github.com/overleaf/overleaf/wiki/Updating-Mongo-version).
+- Print warning when `SHARELATEX_LISTEN_IP` is not defined.
+
+## 2021-10-13
+### Added
+- HTTP to HTTPS redirection.
+  - Listen mode of the `sharelatex` container now `localhost` only, so the value of `SHARELATEX_LISTEN_IP` must be set to the public IP address for direct container access. 
+
+## 2021-08-12
 ### Added
 - Server Pro: New variable to control LDAP and SAML, `EXTERNAL_AUTH`, which can
   be set to one of `ldap`, `saml`, `none`. This is the preferred way to activate
@@ -10,9 +21,11 @@
   - This should not affect current installations. Please contact support if you
     encounter any problems
   - See [LDAP](./doc/ldap.md) and [SAML](./doc/saml.md) documentation for more
+
+## 2020-11-25
+### Added
 - `bin/upgrade` displays any changes to the changelog and prompts for
    confirmation before applying the remote changes to the local branch.
-
 ### Misc
 - Fix code linting errors in bin/ scripts
 

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -81,7 +81,7 @@ function __main__() {
     NGINX_ENABLED="false"
   fi
 
-  if [ -z ${SHARELATEX_LISTEN_IP+x} ]; 
+  if [ -z ${SHARELATEX_LISTEN_IP} ]; 
   then 
     echo "WARNING: the value of SHARELATEX_LISTEN_IP is not set in config/overleaf.rc. This value must be set to the public IP address for direct container access. Defaulting to 0.0.0.0"
     SHARELATEX_LISTEN_IP="0.0.0.0"

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -81,6 +81,12 @@ function __main__() {
     NGINX_ENABLED="false"
   fi
 
+  if [ -z ${SHARELATEX_LISTEN_IP+x} ]; 
+  then 
+    echo "WARNING: the value of SHARELATEX_LISTEN_IP is not set in config/overleaf.rc. This value must be set to the public IP address for direct container access. Defaulting to 0.0.0.0"
+    SHARELATEX_LISTEN_IP="0.0.0.0"
+  fi
+
   if [[ "$NGINX_ENABLED" == "true" ]]; then
     if [[ -n "${TLS_PRIVATE_KEY_PATH-}" ]]; then
       TLS_PRIVATE_KEY_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$TLS_PRIVATE_KEY_PATH")

--- a/doc/overleaf-rc.md
+++ b/doc/overleaf-rc.md
@@ -26,6 +26,8 @@ Sets the path to the directory that will be mounted into the main `sharelatex` c
 
 Sets the host IP address(es) that the container will bind to. For example, if this is set to `0.0.0.0`, then the web interface will be available on any host IP address.
 
+Since https://github.com/overleaf/toolkit/pull/77 the listen mode of the application container was changed to `localhost` only, so the value of `SHARELATEX_LISTEN_IP` must be set to the public IP address for direct container access.
+
 Setting `SHARELATEX_LISTEN_IP` to either `0.0.0.0` or the external IP of your host will typically cause errors when used in conjunction with the [TLS Proxy](tls-proxy.md).
 
 - Default: `127.0.0.1`


### PR DESCRIPTION
## Description

https://github.com/overleaf/toolkit/pull/77 changed the default listen mode from any IP to localhost only, which might be problematic for configurations generated before that was merged.

This PR adds some extra documentation to the variable and emits a warning when the value is not set (and defaults it to 0.0.0.0)

Output:
```
$ bin/up
WARNING: the value of SHARELATEX_LISTEN_IP is not set in config/overleaf.rc. This value must be set to the public IP address for direct container access. Defaulting to 0.0.0.0
Creating redis ... done
Creating mongo ... done
```




## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
