### PR TITLE
Make `git clone` commands match

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The [Developer wiki](https://github.com/overleaf/overleaf/wiki) contains further
 Clone this repository locally:
 
 ``` sh
-git clone https://github.com/overleaf/toolkit.git ./overleaf
+git clone https://github.com/overleaf/toolkit.git ./overleaf-toolkit
 ```
 
 Then follow the [Quick Start Guide](./doc/quick-start-guide.md).


### PR DESCRIPTION
## Description

`git-clone` instruction in main README should match that in the Quick Start.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
