### PR TITLE
Migrate to Compose v2

### DIFF
--- a/bin/compose
+++ b/bin/compose
@@ -38,7 +38,7 @@ function __main__() {
   # shellcheck disable=SC1090
   source "$RC_FILE"
 
-  # Select which docker-compose files to load
+  # Select which compose files to load
   local compose_file_flags=("-f $TOOLKIT_ROOT/lib/docker-compose.base.yml")
   if [[ "$REDIS_ENABLED" == "true" ]]; then
     compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.redis.yml")
@@ -54,12 +54,12 @@ function __main__() {
   fi
 
 
-  # Include docker-compose.override.yml if it is present
+  # Include compose.override.yml if it is present
   if [[ -f "$TOOLKIT_ROOT/config/docker-compose.override.yml" ]]; then
     compose_file_flags+=("-f $TOOLKIT_ROOT/config/docker-compose.override.yml")
   fi
 
-  # Build up the flags to pass to docker-compose
+  # Build up the flags to pass to compose
   local project_name="${PROJECT_NAME:-overleaf}"
 
   local image_name="sharelatex/sharelatex"
@@ -111,7 +111,7 @@ function __main__() {
     echo "<<<<<<<<<<<<<<<<<<<<"
   fi
 
-  # Export vars for use in docker-compose files
+  # Export vars for use in docker compose files
   export DOCKER_SOCKET_PATH
   export IMAGE="$full_image_spec"
   export MONGO_DATA_PATH
@@ -134,7 +134,7 @@ function __main__() {
   export TLS_PRIVATE_KEY_PATH
 
   # shellcheck disable=SC2068
-  exec docker-compose -p "$project_name" ${compose_file_flags[@]} "$@"
+  exec docker compose -p "$project_name" ${compose_file_flags[@]} "$@"
 }
 
 __main__ "$@"

--- a/bin/doctor
+++ b/bin/doctor
@@ -113,7 +113,7 @@ function check_dependencies() {
   declare -a binaries=(
     bash
     docker
-    docker-compose
+    docker compose
     realpath
     perl
     awk

--- a/bin/logs
+++ b/bin/logs
@@ -78,7 +78,7 @@ function __main__() {
 
     local bash_exec_command_string="tail $FOLLOW_FLAG -n $LINES $path_spec"
 
-    exec "$TOOLKIT_ROOT/bin/docker-compose" exec sharelatex bash -c "$bash_exec_command_string"
+    exec "$TOOLKIT_ROOT/bin/compose" exec sharelatex bash -c "$bash_exec_command_string"
 }
 
 __main__ "$@"

--- a/bin/mongo
+++ b/bin/mongo
@@ -16,7 +16,7 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
 fi
 
 function __main__() {
-  exec "$TOOLKIT_ROOT/bin/docker-compose" exec mongo mongo sharelatex
+  exec "$TOOLKIT_ROOT/bin/compose" exec mongo mongo sharelatex
 }
 
 __main__ "$@"

--- a/bin/shell
+++ b/bin/shell
@@ -16,7 +16,7 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
 fi
 
 function __main__() {
-  exec "$TOOLKIT_ROOT/bin/docker-compose" exec sharelatex bash
+  exec "$TOOLKIT_ROOT/bin/compose" exec sharelatex bash
 }
 
 __main__ "$@"

--- a/bin/start
+++ b/bin/start
@@ -16,7 +16,7 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
 fi
 
 function __main__() {
-  exec "$TOOLKIT_ROOT/bin/docker-compose" start "$@"
+  exec "$TOOLKIT_ROOT/bin/compose" start "$@"
 }
 
 __main__ "$@"

--- a/bin/stop
+++ b/bin/stop
@@ -16,7 +16,7 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
 fi
 
 function __main__() {
-  exec "$TOOLKIT_ROOT/bin/docker-compose" stop "$@"
+  exec "$TOOLKIT_ROOT/bin/compose" stop "$@"
 }
 
 __main__ "$@"

--- a/bin/up
+++ b/bin/up
@@ -18,9 +18,9 @@ fi
 function usage() {
   echo "Usage: bin/up [FLAGS...]"
   echo ""
-  echo "A wrapper around 'docker-compose up'."
+  echo "A wrapper around 'docker compose up'."
   echo ""
-  echo "This program will pass any extra flags to docker-compose,"
+  echo "This program will pass any extra flags to docker compose,"
   echo "for example: 'bin/up -d' will run in detached mode"
 }
 
@@ -38,7 +38,7 @@ function __main__() {
     exit
   fi
   check_config
-  exec "$TOOLKIT_ROOT/bin/docker-compose" up "$@"
+  exec "$TOOLKIT_ROOT/bin/compose" up "$@"
 }
 
 __main__ "$@"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -29,7 +29,7 @@ function usage() {
 
 function services_up() {
   local top_output
-  top_output="$("$TOOLKIT_ROOT/bin/docker-compose" top)"
+  top_output="$("$TOOLKIT_ROOT/bin/compose" top)"
   if [[ -z "$top_output" ]]; then
     return 1
   else
@@ -130,7 +130,7 @@ function handle_image_upgrade() {
     fi
     services_stopped="true"
     echo "Stopping docker services"
-    "$TOOLKIT_ROOT/bin/docker-compose" stop
+    "$TOOLKIT_ROOT/bin/compose" stop
   fi
 
   ## Advise the user to take a backup
@@ -157,7 +157,7 @@ function handle_image_upgrade() {
     read -r -p "Start docker services again? [y/n] " should_start
     if [[ "$should_start" =~ [Yy] ]]; then
       echo "Starting docker services"
-      "$TOOLKIT_ROOT/bin/docker-compose" up -d
+      "$TOOLKIT_ROOT/bin/compose" up -d
     fi
   fi
 }

--- a/doc/README.md
+++ b/doc/README.md
@@ -16,7 +16,7 @@ documentation on the [Overleaf Wiki](https://github.com/overleaf/overleaf/wiki)
 ## Using the Toolkit
 
 - [The Doctor](./the-doctor.md)
-- [Working with Docker-Compose Services](./docker-compose.md)
+- [Working with Compose Services](./compose.md)
 
 
 ## Configuration

--- a/doc/ce-upgrading-texlive.md
+++ b/doc/ce-upgrading-texlive.md
@@ -78,6 +78,6 @@ services:
         image: sharelatex/sharelatex:with-texlive-full
 ```
 
-Then run `bin/stop && bin/docker-compose rm -f sharelatex && bin/up`, to recreate the container.
+Then run `bin/stop && bin/compose rm -f sharelatex && bin/up`, to recreate the container.
 
 Note that you will need to remove this committed container and repeat these steps when you [upgrade](./upgrading.md).

--- a/doc/compose.md
+++ b/doc/compose.md
@@ -1,8 +1,8 @@
-# Working with Docker-Compose Services
+# Working with Compose Services
 
 The Overleaf Toolkit runs Overleaf inside a docker container, plus the
 supporting databases (MongoDB and Redis), in their own containers. All of this
-is orchestrated with `docker-compose`.
+is orchestrated with `docker compose`.
 
 Note: for legacy reasons, the main Overleaf container is called `sharelatex`,
 and is based on the `sharelatex/sharelatex` docker image. This is because the
@@ -13,36 +13,36 @@ for more details. At some point in the future, this will be renamed to match the
 Overleaf naming scheme.
 
 
-## The `bin/docker-compose` Wrapper
+## The `bin/compose` Wrapper
 
-The `bin/docker-compose` script is a wrapper around `docker-compose`. It
+The `bin/compose` script is a wrapper around `docker compose`. It
 loads configuration from the `config/` directory, before invoking
-`docker-compose` with whatever arguments were passed to the script.
+`docker compose` with whatever arguments were passed to the script.
 
-You can treat `bin/docker-compose` as a transparent wrapper for the
-`docker-compose` program installed on your machine.
+You can treat `bin/docker compose` as a transparent wrapper for the
+`docker compose` program installed on your machine.
 
 For example, we can check which containers are running with the following:
 
-```
-$ bin/docker-compose ps
+```shell
+bin/docker compose ps
 ```
 
 
 ## Convenience Helpers
 
-In addition to `bin/docker-compose`, the toolkit also provides a collection of
+In addition to `bin/compose`, the toolkit also provides a collection of
 convenient scripts to automate common tasks:
 
-- `bin/up`: shortcut for `bin/docker-compose up`
-- `bin/start`: shortcut for `bin/docker-compose start`
-- `bin/stop`: shortcut for `bin/docker-compose stop`
+- `bin/up`: shortcut for `bin/compose up`
+- `bin/start`: shortcut for `bin/compose start`
+- `bin/stop`: shortcut for `bin/compose stop`
 - `bin/shell`: starts a shell inside the main container
 
 
 ## Architecture
 
-Inside the overleaf container, the Overleaf software runs as a set of micro-services, managed by `runit`. Some of the more interesting files inside the container are:
+Inside the overleaf container, the Overleaf software runs as a set of microservices, managed by `runit`. Some of the more interesting files inside the container are:
 
 - `/etc/service/`: initialisation files for the microservices
 - `/etc/sharelatex/settings.coffee`: unified settings file for the microservices
@@ -53,12 +53,12 @@ Inside the overleaf container, the Overleaf software runs as a set of micro-serv
 
 ## The MongoDB and Redis Containers
 
-Overleaf dedends on two external databases: MongoDB and Redis. By default, the toolkit will provision a container for each of these databases, in addition to the Overleaf container, for a total of three docker containers.
+Overleaf depends on two external databases: MongoDB and Redis. By default, the toolkit will provision a container for each of these databases, in addition to the Overleaf container, for a total of three docker containers.
 
-If you would prefer to connect to an existing MongoDB or Redis instance, you can do so by setting the appropriate settings in  the [overleaf.rc](./overleaf-rc.md) configuration file.
+If you prefer to connect to an existing MongoDB or Redis instance, you can do so by setting the appropriate settings in  the [overleaf.rc](./overleaf-rc.md) configuration file.
 
 
-## Viewing Individual Micro-Service Logs
+## Viewing Individual Microservice Logs
 
 The `bin/logs` script allows you to select individual log streams from inside the overleaf container.
 For example, if you want to see just the logs for the `web` and `clsi` (compiler) micro-services, run:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -11,7 +11,7 @@ This directory is excluded from the git revision control system, so it will not 
 Note that changes to the configuration files will not be automatically applied
 to existing containers, even if the container is stopped and restarted (with
 `bin/stop` and `bin/start`). To apply the changes, run `bin/up`, and
-`docker-compose` will automatically apply the configuration changes to a new
+`compose` will automatically apply the configuration changes to a new
 container. (Or, run `bin/up -d`, if you prefer to not attach to the docker logs)
 
 
@@ -38,7 +38,7 @@ The `config/overleaf.rc` file is the most important contains the most important 
 
 See [The full specification](./overleaf-rc.md) for more details on the supported options. 
 
-Note: we recommend that you re-create the docker containers after changing anything in `overleaf.rc` or `variables.env`, by running `bin/docker-compose down`, followed by `bin/up`
+Note: we recommend that you re-create the docker containers after changing anything in `overleaf.rc` or `variables.env`, by running `bin/compose down`, followed by `bin/up`
 
 
 ## The `variables.env` File
@@ -55,4 +55,4 @@ The `config/version` file contains the version number of the docker images that 
 
 If present, the `config/docker-compose.override.yml` file will be included in the invocation to `docker-compose`. This is useful for overriding configuration specific to docker-compose.
 
-See the [docker-compose documentation](https://docs.docker.com/compose/extends/#adding-and-overriding-configuration) for more details.
+See the [compose documentation](https://docs.docker.com/compose/extends/#adding-and-overriding-configuration) for more details.

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,7 +1,7 @@
 # Dependencies
 
 This project requires a modern unix system as a base (such as Ubuntu Linux).
-It also requires `bash`, `docker`, and `docker-compose`. 
+It also requires `bash`, `docker`, and `compose`. 
 
 The `bin/doctor` script can be used to check for missing dependencies.
 

--- a/doc/getting-server-pro.md
+++ b/doc/getting-server-pro.md
@@ -19,7 +19,7 @@ Username: <sharelatex+your_key_name>
 Password: <your key>
 ```
 
-Then run `bin/docker-compose pull` to pull the image from the `quay.io` registry.
+Then run `bin/compose pull` to pull the image from the `quay.io` registry.
 
 
 ## Switching your installation to Server Pro 

--- a/doc/overleaf-rc.md
+++ b/doc/overleaf-rc.md
@@ -3,14 +3,14 @@
 This document describes the variables that are supported in the `config/overleaf.rc` file.
 This file consists of variable definitions in the form `NAME=value`. Lines beginning with `#` are treated as comments.
 
-Note: we recommend that you re-create the docker containers after changing anything in `overleaf.rc` or `variables.env`, by running `bin/docker-compose down`, followed by `bin/up`
+Note: we recommend that you re-create the docker containers after changing anything in `overleaf.rc` or `variables.env`, by running `bin/compose down`, followed by `bin/up`
 
 ## Variables
 
 
 ### `PROJECT_NAME`
 
-Sets the value of the `--project-name` flag supplied to `docker-compose`.
+Sets the value of the `--project-name` flag supplied to `docker compose`.
 This is useful when running multiple instances of Overleaf on one host, as each instance can have a different project name.
 
 - Default: overleaf

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -18,9 +18,9 @@ Community Edition is the free version of Overleaf, while Server Pro is our enter
 When you set up Overleaf using the toolkit, you will start with Community Edition, and can easily switch to Server Pro by changing just one setting.
 
 
-## Docker, Docker-Compose, and Overleaf
+## Docker, Compose, and Overleaf
 
-The toolkit uses [Docker](https://www.docker.com) and [Docker-Compose](https://docs.docker.com/compose/) to run the Overleaf software in an isolated sandbox. While we do recommend becoming familiar with both Docker and Docker-Compose, we also aim to make it as easy as possible to run Overleaf on your own computer.
+The toolkit uses [Docker](https://www.docker.com) and [Compose](https://docs.docker.com/compose/) to run the Overleaf software in an isolated sandbox. While we do recommend becoming familiar with both Docker and Compose, we also aim to make it as easy as possible to run Overleaf on your own computer.
 
 
 ## How do I get the Toolkit?

--- a/doc/quick-start-guide.md
+++ b/doc/quick-start-guide.md
@@ -5,10 +5,10 @@
 The Overleaf Toolkit depends on the following programs:
 
 - bash
-- docker
-- docker-compose
+- [docker](https://www.docker.com/)
+- [compose](https://docs.docker.com/compose/)
 
-We recommend that you install the most recent version of docker and docker-compose that 
+We recommend that you install the most recent version of docker and compose that 
 are available on your system.
 
 
@@ -78,7 +78,7 @@ These are the three configuration files you will interact with:
 
 ## Starting Up
 
-The Overleaf Toolkit uses `docker-compose` to manage the overleaf docker containers. The toolkit provides a set of scripts which wrap `docker-compose`, and take care of most of the details for you.
+The Overleaf Toolkit uses `compose` to manage the overleaf docker containers. The toolkit provides a set of scripts which wrap the `docker compose` command and take care of most of the details for you.
 
 Let's start the docker services:
 
@@ -87,7 +87,7 @@ $ bin/up
 ```
 
 You should see some log output from the docker containers, indicating that the containers are running. 
-If you press `CTRL-C` at the terminal, the services will shut down. You can start them up again (without attaching to the log output) by running `bin/start`. More generally, you can run `bin/docker-compose` to control the `docker-compose` system directly, if you find that the convenience scripts don't cover your use-case.
+If you press `^C` (ctrl+c) at the terminal, the services will shut down. You can start them up again (without attaching to the log output) by running `bin/start`. More generally, you can run `bin/compose` to control the `compose` system directly, if you find that the convenience scripts don't cover your use-case.
 
 
 ## Create the first admin account
@@ -162,9 +162,9 @@ We should see some output similar to this:
     - docker
         - status: present
         - version info: Docker version 19.03.6, build 369ce74a3c
-    - docker-compose
+    - compose
         - status: present
-        - version info: docker-compose version 1.24.0, build 0aa59064
+        - version info: compose version 2.13.0, build 7171ad9b
     ...
 ====== Configuration ======
     ...
@@ -180,7 +180,7 @@ When you run into problems with your toolkit, you should first run the doctor sc
 
 ## Getting Help
 
-Users of the free Community Edition should [open an issue on github](https://github.com/overleaf/toolkit/issues). 
+Users of the free Community Edition should [open an issue on GitHub](https://github.com/overleaf/toolkit/issues). 
 
 Users of Server Pro should contact `support@overleaf.com` for assistance.
 

--- a/doc/the-doctor.md
+++ b/doc/the-doctor.md
@@ -38,10 +38,10 @@ You will see some output like this:
         - version info: 5.0.17(1)-release
     - docker
         - status: present
-        - version info: Docker version 19.03.6, build 369ce74a3c
-    - docker-compose
+        - version info: Docker version 20.10.21, build 448daf9340
+    - compose
         - status: present
-        - version info: docker-compose version 1.24.0, build 0aa59064
+        - version info: compose version 2.14.0, build 7171ad9b02
     - realpath
         - status: present
         - version info: realpath (GNU coreutils) 8.30

--- a/doc/upgrading-from-0.x.md
+++ b/doc/upgrading-from-0.x.md
@@ -30,10 +30,10 @@ It is safe to delete it when the application (Server CE/Pro) is not running.
 # cd ~/toolkit
 
 # Stop the application
-bin/docker-compose stop sharelatex
+bin/compose stop sharelatex
 
 # Check the existing indexes
-echo 'db.projectInvites.getIndexes()' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.projectInvites.getIndexes()' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output variant 1 (use of Server CE from August 2016, changed `expireAfterSeconds` attribute):
 #    [
 #            ...
@@ -67,7 +67,7 @@ echo 'db.projectInvites.getIndexes()' | bin/docker-compose exec -T mongo mongo -
 
 
 # Also check for completed migrations
-echo 'db.migrations.count({"name":"20190912145023_create_projectInvites_indexes"})' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.migrations.count({"name":"20190912145023_create_projectInvites_indexes"})' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output:
 #    0
 
@@ -77,12 +77,12 @@ echo 'db.migrations.count({"name":"20190912145023_create_projectInvites_indexes"
 
 # If the output matches, continue below.
 # Drop the expires_1 index
-echo 'db.projectInvites.dropIndex("expires_1")' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.projectInvites.dropIndex("expires_1")' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output (NOTE: the "nIndexesWas" number may differ)
 #    { "nIndexesWas" : 3, "ok" : 1 }
 
 # Start the application again
-bin/docker-compose start sharelatex
+bin/compose start sharelatex
 ```
 
 #### templates
@@ -100,10 +100,10 @@ Please make sure that the application (Server CE/Pro) is not running.
 # cd ~/toolkit
 
 # Stop the application
-bin/docker-compose stop sharelatex
+bin/compose stop sharelatex
 
 # Check the existing indexes
-echo 'db.templates.getIndexes()' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.templates.getIndexes()' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output (use of an old mongodb version, offending `"safe":null` attribute):
 #    [
 #        ...
@@ -141,7 +141,7 @@ echo 'db.templates.getIndexes()' | bin/docker-compose exec -T mongo mongo --quie
 #    ]
 
 # Also check for completed migrations
-echo 'db.migrations.count({"name":"20190912145030_create_templates_indexes"})' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.migrations.count({"name":"20190912145030_create_templates_indexes"})' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output:
 #    0
 
@@ -151,18 +151,18 @@ echo 'db.migrations.count({"name":"20190912145030_create_templates_indexes"})' |
 
 # If the output matches, continue below.
 # Drop the project_id_1, user_id_1 and name_1 index
-echo 'db.templates.dropIndex("project_id_1")' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.templates.dropIndex("project_id_1")' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output (NOTE: the "nIndexesWas" number may differ)
 #    { "nIndexesWas" : 4, "ok" : 1 }
-echo 'db.templates.dropIndex("user_id_1")' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.templates.dropIndex("user_id_1")' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output (NOTE: the "nIndexesWas" number may differ)
 #    { "nIndexesWas" : 3, "ok" : 1 }
-echo 'db.templates.dropIndex("name_1")' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.templates.dropIndex("name_1")' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output (NOTE: the "nIndexesWas" number may differ)
 #    { "nIndexesWas" : 2, "ok" : 1 }
 
 # Start the application again
-bin/docker-compose start sharelatex
+bin/compose start sharelatex
 ```
 
 ### Users with non-unique emails
@@ -180,7 +180,7 @@ The first step is identifying the scope of this issue:
 # cd ~/toolkit
 
 # list emails that have more than one related user when normalized to lower case.
-echo 'db.users.aggregate([{"$group":{"_id":{"$toLower":"$email"},"count":{"$sum":1}}},{"$match":{"count":{"$gt":1}}}])' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.users.aggregate([{"$group":{"_id":{"$toLower":"$email"},"count":{"$sum":1}}},{"$match":{"count":{"$gt":1}}}])' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output
 #    { "_id" : "foo@bar.com", "count" : 2 }
 #    ...
@@ -207,7 +207,7 @@ There are two options to deal with a duplicate.
 # Change the email of one of the accounts and deal with the project access later.
 # Replace the three placeholders "foo@bar.com" with an actual email address that has two related users.
 # The "^" and "$" characters around the email ensure that we do not match similar emails, e.g. "this-is-not-foo@bar.com" also contains "foo@bar.com".
-echo 'db.users.updateOne({"email":/^foo@bar.com$/i},{"$set":{"email":"duplicate-foo@bar.com","emails.0.email":"duplicate-foo@bar.com"}})' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.users.updateOne({"email":/^foo@bar.com$/i},{"$set":{"email":"duplicate-foo@bar.com","emails.0.email":"duplicate-foo@bar.com"}})' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output
 #    { "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
 ``` 
@@ -218,7 +218,7 @@ echo 'db.users.updateOne({"email":/^foo@bar.com$/i},{"$set":{"email":"duplicate-
 # Find exact casing of the email addresses
 # Replace the placeholder "foo@bar.com" with an actual email address that has two related users.
 # The "^" and "$" characters around the email ensure that we do not match similar emails, e.g. "this-is-not-foo@bar.com" also contains "foo@bar.com".
-echo 'db.users.find({"email":/^foo@bar.com$/i},{"email":1})' | bin/docker-compose exec -T mongo mongo --quiet sharelatex
+echo 'db.users.find({"email":/^foo@bar.com$/i},{"email":1})' | bin/compose exec -T mongo mongo --quiet sharelatex
 # Expected output
 #    { "_id" : ObjectId("637276cd42fab6008ec8c88c"), "email" : "foo@bar.com" }
 #    { "_id" : ObjectId("637276cd42fab6008ec8c88d"), "email" : "FOO@bar.com" }

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+version: "3.9"
 services:
 
     sharelatex:

--- a/lib/docker-compose.mongo.yml
+++ b/lib/docker-compose.mongo.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+version: "2.2"
 services:
 
     mongo:

--- a/lib/docker-compose.mongo.yml
+++ b/lib/docker-compose.mongo.yml
@@ -1,5 +1,5 @@
 ---
-version: "2.2"
+version: "3.9"
 services:
 
     mongo:

--- a/lib/docker-compose.nginx.yml
+++ b/lib/docker-compose.nginx.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+version: "3.9"
 services:
 
   nginx:

--- a/lib/docker-compose.redis.yml
+++ b/lib/docker-compose.redis.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+version: "3.9"
 services:
 
     redis:

--- a/lib/docker-compose.sibling-containers.yml
+++ b/lib/docker-compose.sibling-containers.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+version: "3.9"
 services:
   sharelatex:
     volumes:


### PR DESCRIPTION
## Description
- Updated references to `docker-compose` command to `docker compose`
- Moved `bin/docker-compose` → `bin/compose` to align with Compose's new terminology (they call it compose, not docker compose) and updated references to this file
- Updated references to `docker-compose` project to `compose`


## Related issues / Pull Requests
- fixes #119 


## Contributor Agreement

- [✅] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
