### PR TITLE
added SIGKILL timeouts for docker 

### DIFF
--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -14,4 +14,9 @@ services:
           SHARELATEX_MONGO_URL: "${MONGO_URL}"
           SHARELATEX_REDIS_HOST: "${REDIS_HOST}"
           REDIS_HOST: "${REDIS_HOST}"
+          # Give children processes delay to timeout
+          KILL_PROCESS_TIMEOUT: 60
+          # Give all other processes (such as those which have been forked) delay to timeout
+          KILL_ALL_PROCESSES_TIMEOUT: 60
         env_file: ../config/variables.env
+        stop_grace_period: 60s

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -14,9 +14,5 @@ services:
           SHARELATEX_MONGO_URL: "${MONGO_URL}"
           SHARELATEX_REDIS_HOST: "${REDIS_HOST}"
           REDIS_HOST: "${REDIS_HOST}"
-          # Give children processes delay to timeout
-          KILL_PROCESS_TIMEOUT: 60
-          # Give all other processes (such as those which have been forked) delay to timeout
-          KILL_ALL_PROCESSES_TIMEOUT: 60
         env_file: ../config/variables.env
         stop_grace_period: 60s


### PR DESCRIPTION
## Description

`stop_grace_period` specifies how long to wait when attempting to stop a container if it doesn’t handle `SIGTERM`, while `KILL_PROCESS_TIMEOUT` and `KILL_ALL_PROCESSES_TIMEOUT` specifies the timeout within phusion image, giving time for the pre-shutdown script to flush data from redis.

`KILL_PROCESS_TIMEOUT` and `KILL_ALL_PROCESSES_TIMEOUT` are defined in the Dockerfile, and can be overriden via `variables.env`.

https://github.com/phusion/baseimage-docker#shutting-down-your-process



## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
