### PR TITLE
Support git bridge in Server Pro

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -15,28 +15,17 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
   exit 1
 fi
 
-RC_FILE="$TOOLKIT_ROOT/config/overleaf.rc"
-
 function __main__() {
-  local SHARELATEX_IMAGE_VERSION
-  SHARELATEX_IMAGE_VERSION="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
-  local MONGO_IMAGE="mongo:4.0"
-  local REDIS_IMAGE="redis:5.0"
-  local NGINX_IMAGE="nginx:1.19-alpine"
-
-  local MONGO_URL="mongodb://mongo/sharelatex"
-  local REDIS_HOST="redis"
-  local REDIS_PORT="6379"
-
-  if [[ ! "$SHARELATEX_IMAGE_VERSION" \
+  local IMAGE_VERSION
+  IMAGE_VERSION="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
+  if [[ ! "$IMAGE_VERSION" \
           =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC)?$ ]]; then
-    echo "ERROR: invalid version '${SHARELATEX_IMAGE_VERSION}'"
+    echo "ERROR: invalid version '${IMAGE_VERSION}'"
     exit 1
   fi
 
   # Load vars from the rc file
-  # shellcheck disable=SC1090
-  source "$RC_FILE"
+  read_config
 
   # Select which docker-compose files to load
   local compose_file_flags=("-f $TOOLKIT_ROOT/lib/docker-compose.base.yml")
@@ -49,41 +38,35 @@ function __main__() {
   if [[ "$SIBLING_CONTAINERS_ENABLED" == "true" ]]; then
     compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.sibling-containers.yml")
   fi
-  if [[ "${NGINX_ENABLED:-false}" == "true" ]]; then
+  if [[ "${NGINX_ENABLED}" == "true" ]]; then
     compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.nginx.yml")
   fi
-
+  if [[ "${GIT_BRIDGE_ENABLED}" == "true" ]]; then
+    compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.git-bridge.yml")
+    GIT_BRIDGE_IMAGE="quay.io/sharelatex/git-bridge:$IMAGE_VERSION"
+  fi
 
   # Include docker-compose.override.yml if it is present
   if [[ -f "$TOOLKIT_ROOT/config/docker-compose.override.yml" ]]; then
     compose_file_flags+=("-f $TOOLKIT_ROOT/config/docker-compose.override.yml")
   fi
 
-  # Build up the flags to pass to docker-compose
-  local project_name="${PROJECT_NAME:-overleaf}"
-
   local image_name="sharelatex/sharelatex"
-  if [[ "${SERVER_PRO:-null}" == "true" ]]; then
+  if [[ "${SERVER_PRO}" == "true" ]]; then
     image_name="quay.io/sharelatex/sharelatex-pro"
   fi
   image_name="${SHARELATEX_IMAGE_NAME:-${image_name}}"
 
-  local full_image_spec="$image_name:$SHARELATEX_IMAGE_VERSION"
+  local full_image_spec="$image_name:$IMAGE_VERSION"
 
   # Canonicalize data paths
   SHARELATEX_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$SHARELATEX_DATA_PATH")
   MONGO_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$MONGO_DATA_PATH")
   REDIS_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$REDIS_DATA_PATH")
-  
-  # users with old config/ content might not have NGINX_ENABLED in their
-  # overleaf.rc, this initialisation prevents an `unbound variable` error
-  if [ -z ${NGINX_ENABLED+x} ]; 
-  then 
-    NGINX_ENABLED="false"
-  fi
+  GIT_BRIDGE_DATA_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$GIT_BRIDGE_DATA_PATH")
 
-  if [ "${SHARELATEX_LISTEN_IP:-null}" == "null" ]; 
-  then 
+  if [ "${SHARELATEX_LISTEN_IP:-null}" == "null" ];
+  then
     echo "WARNING: the value of SHARELATEX_LISTEN_IP is not set in config/overleaf.rc. This value must be set to the public IP address for direct container access. Defaulting to 0.0.0.0"
     SHARELATEX_LISTEN_IP="0.0.0.0"
   fi
@@ -103,10 +86,10 @@ function __main__() {
   if [[ "${RC_DEBUG:-null}" != "null" ]]; then
     echo ">>>>>>VARS>>>>>>"
     echo "$(set -o posix; set)" # print all vars
-    echo "IMAGE_VERSION=$SHARELATEX_IMAGE_VERSION"
+    echo "IMAGE_VERSION=$IMAGE_VERSION"
     echo "<<<<<<<<<<<<<<<<"
     echo ">>>>COMPOSE-ARGS>>>>"
-    echo "-p $project_name"
+    echo "-p $PROJECT_NAME"
     echo "${compose_file_flags[@]}"
     echo "$@"
     echo "<<<<<<<<<<<<<<<<<<<<"
@@ -114,6 +97,9 @@ function __main__() {
 
   # Export vars for use in docker-compose files
   export DOCKER_SOCKET_PATH
+  export GIT_BRIDGE_DATA_PATH
+  export GIT_BRIDGE_ENABLED
+  export GIT_BRIDGE_IMAGE
   export IMAGE="$full_image_spec"
   export MONGO_DATA_PATH
   export MONGO_IMAGE
@@ -135,7 +121,14 @@ function __main__() {
   export TLS_PRIVATE_KEY_PATH
 
   # shellcheck disable=SC2068
-  exec docker-compose -p "$project_name" ${compose_file_flags[@]} "$@"
+  exec docker-compose -p "$PROJECT_NAME" ${compose_file_flags[@]} "$@"
+}
+
+function read_config () {
+  # shellcheck source=../lib/default.rc
+  source "$TOOLKIT_ROOT/lib/default.rc"
+  # shellcheck source=/dev/null
+  source "$TOOLKIT_ROOT/config/overleaf.rc"
 }
 
 __main__ "$@"

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -18,11 +18,11 @@ fi
 function __main__() {
   local IMAGE_VERSION
   IMAGE_VERSION="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
-  if [[ ! "$IMAGE_VERSION" \
-          =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC)?$ ]]; then
+  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-RC)?$ ]]; then
     echo "ERROR: invalid version '${IMAGE_VERSION}'"
     exit 1
   fi
+  local IMAGE_VERSION_MAJOR=${BASH_REMATCH[1]}
 
   # Load vars from the rc file
   read_config
@@ -41,9 +41,14 @@ function __main__() {
   if [[ "${NGINX_ENABLED}" == "true" ]]; then
     compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.nginx.yml")
   fi
-  if [[ "${GIT_BRIDGE_ENABLED}" == "true" ]]; then
-    compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.git-bridge.yml")
-    GIT_BRIDGE_IMAGE="quay.io/sharelatex/git-bridge:$IMAGE_VERSION"
+  if [[ $GIT_BRIDGE_ENABLED = "true" ]]; then
+    if [[ $SERVER_PRO = "true" && $IMAGE_VERSION_MAJOR -ge 4 ]]; then
+      compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.git-bridge.yml")
+      GIT_BRIDGE_IMAGE="quay.io/sharelatex/git-bridge:$IMAGE_VERSION"
+    else
+      # Git bridge is only supported in Server Pro 4+
+      GIT_BRIDGE_ENABLED=false
+    fi
   fi
 
   # Include docker-compose.override.yml if it is present

--- a/bin/doctor
+++ b/bin/doctor
@@ -255,6 +255,8 @@ function check_config_files() {
           print_point 2 "TLS_PORT: $TLS_PORT"
         fi
 
+        print_point 2 "GIT_BRIDGE_ENABLED: ${GIT_BRIDGE_ENABLED:-null}"
+
       elif [[ "$config_file" == "config/variables.env" ]]; then
         print_point 1 "values"
 
@@ -341,6 +343,14 @@ function check_config_files() {
           fi
         else
           print_point 2 "SHARELATEX_HISTORY_BACKEND: fs"
+        fi
+
+        if [[ -n ${GIT_BRIDGE_ENABLED:-} ]]; then
+          if [[ -n ${GIT_BRIDGE_OAUTH2_CLIENT_SECRET:-} ]]; then
+            print_point 2 "GIT_BRIDGE_OAUTH2_CLIENT_SECRET: [set here]"
+          else
+            add_warning "GIT_BRIDGE_OAUTH2_CLIENT_SECRET is missing in variables.env"
+          fi
         fi
       fi
     fi

--- a/lib/common.env
+++ b/lib/common.env
@@ -1,0 +1,1 @@
+GIT_BRIDGE_OAUTH2_CLIENT_ID="overleaf-git-bridge"

--- a/lib/config-seed/overleaf.rc
+++ b/lib/config-seed/overleaf.rc
@@ -23,13 +23,20 @@ MONGO_IMAGE=mongo:4.4
 REDIS_ENABLED=true
 REDIS_DATA_PATH=data/redis
 
+# Git-bridge configuration (Server Pro only)
+#
+# If you enable git bridge, you must also set GIT_BRIDGE_OAUTH2_CLIENT_SECRET
+# in variables.env
+GIT_BRIDGE_ENABLED=true
+GIT_BRIDGE_DATA_PATH=data/git-bridge
+
 # TLS proxy configuration (optional)
 # See documentation in doc/tls-proxy.md
 NGINX_ENABLED=false
 NGINX_CONFIG_PATH=config/nginx/nginx.conf
 NGINX_HTTP_PORT=80
 # Replace these IP addresses with the external IP address of your host
-NGINX_HTTP_LISTEN_IP=127.0.1.1 
+NGINX_HTTP_LISTEN_IP=127.0.1.1
 NGINX_TLS_LISTEN_IP=127.0.1.1
 TLS_PRIVATE_KEY_PATH=config/nginx/certs/overleaf_key.pem
 TLS_CERTIFICATE_PATH=config/nginx/certs/overleaf_certificate.pem

--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -1,4 +1,4 @@
-SHARELATEX_APP_NAME=Our Overleaf Instance
+SHARELATEX_APP_NAME="Our Overleaf Instance"
 
 ENABLED_LINKED_FILE_TYPES=project_file,project_output_file
 

--- a/lib/default.rc
+++ b/lib/default.rc
@@ -1,0 +1,33 @@
+# Default values for config/overleaf.rc
+
+PROJECT_NAME=overleaf
+SERVER_PRO=false
+SHARELATEX_DATA_PATH=data/sharelatex
+SHARELATEX_PORT=80
+
+# Sibling containers
+SIBLING_CONTAINERS_ENABLED=false
+DOCKER_SOCKET_PATH=/var/run/docker.sock
+
+# Mongo configuration
+MONGO_ENABLED=true
+MONGO_IMAGE=mongo:4.0
+MONGO_URL=mongodb://mongo/sharelatex
+
+# Redis configuration
+REDIS_ENABLED=true
+REDIS_IMAGE=redis:5.0
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DATA_PATH=data/redis
+
+# Git bridge configuration
+GIT_BRIDGE_ENABLED=false
+GIT_BRIDGE_DATA_PATH=data/git-bridge
+
+# TLS proxy configuration
+NGINX_ENABLED=false
+NGINX_IMAGE=nginx:1.19-alpine
+NGINX_CONFIG_PATH=config/nginx/nginx.conf
+NGINX_HTTP_PORT=80
+TLS_PORT=443

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -11,8 +11,12 @@ services:
         ports:
             - "${SHARELATEX_LISTEN_IP:-127.0.0.1}:${SHARELATEX_PORT:-80}:80"
         environment:
+          GIT_BRIDGE_ENABLED: "${GIT_BRIDGE_ENABLED}"
+          REDIS_HOST: "${REDIS_HOST}"
           SHARELATEX_MONGO_URL: "${MONGO_URL}"
           SHARELATEX_REDIS_HOST: "${REDIS_HOST}"
-          REDIS_HOST: "${REDIS_HOST}"
-        env_file: ../config/variables.env
+          V1_HISTORY_URL: "http://sharelatex:3100/api"
+        env_file:
+            - common.env
+            - ../config/variables.env
         stop_grace_period: 60s

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -12,6 +12,8 @@ services:
             - "${SHARELATEX_LISTEN_IP:-127.0.0.1}:${SHARELATEX_PORT:-80}:80"
         environment:
           GIT_BRIDGE_ENABLED: "${GIT_BRIDGE_ENABLED}"
+          GIT_BRIDGE_HOST: "git-bridge"
+          GIT_BRIDGE_PORT: "8000"
           REDIS_HOST: "${REDIS_HOST}"
           SHARELATEX_MONGO_URL: "${MONGO_URL}"
           SHARELATEX_REDIS_HOST: "${REDIS_HOST}"

--- a/lib/docker-compose.git-bridge.yml
+++ b/lib/docker-compose.git-bridge.yml
@@ -1,0 +1,25 @@
+---
+version: '2.2'
+services:
+
+    git-bridge:
+        restart: always
+        image: "${GIT_BRIDGE_IMAGE}"
+        volumes:
+            - "${GIT_BRIDGE_DATA_PATH}:/tmp/wlgb"
+        container_name: git-bridge
+        ports:
+            - "8000:8000"
+        environment:
+          GIT_BRIDGE_API_BASE_URL: "http://sharelatex/api/v0"
+          GIT_BRIDGE_OAUTH2_SERVER: "http://sharelatex"
+          GIT_BRIDGE_POSTBACK_BASE_URL: "http://git-bridge:8000"
+        env_file:
+            - common.env
+            - ../config/variables.env
+        user: root
+        command: ["/server-pro-start.sh"]
+
+    sharelatex:
+      links:
+        - git-bridge

--- a/lib/docker-compose.git-bridge.yml
+++ b/lib/docker-compose.git-bridge.yml
@@ -8,8 +8,8 @@ services:
         volumes:
             - "${GIT_BRIDGE_DATA_PATH}:/tmp/wlgb"
         container_name: git-bridge
-        ports:
-            - "8000:8000"
+        expose:
+            - "8000"
         environment:
           GIT_BRIDGE_API_BASE_URL: "http://sharelatex/api/v0"
           GIT_BRIDGE_OAUTH2_SERVER: "http://sharelatex"


### PR DESCRIPTION
## Description

This adds a new docker compose configuration for git bridge. This configuration is loaded only when GIT_BRIDGE_ENABLED is set to true in config/overleaf.rc

I also added a new lib/default.rc file that sets defaults for variables set in config/overleaf.rc. This is meant to make it easier to specify reasonable defaults without having to change everywhere these variables are interpolated in the bin/docker-compose script.

The GIT_BRIDGE_OAUTH2_CLIENT_SECRET env variable is shared between the git-bridge and sharelatex containers. The easiest way to make it available is to let the user generate it and add it to the configuration. I opted to make it configurable in config/variables.env, but we could discuss other options.

## Testing done

* [x] Bring up the server with the GIT_BRIDGE_ENABLED variable unset (backwards compatible case). The server starts successfully, but the git-bridge container doesn't start.
* [x] Bring up the server with the GIT_BRIDGE_ENABLED variable unset, using our new git-bridge enabled Server Pro images. The git-bridge container doesn't start. The Git feature doesn't appear in the UI.
* [x] Bring up the server with GIT_BRIDGE_ENABLED=true, but without GIT_BRIDGE_OAUTH2_CLIENT_SECRET. The git-bridge container starts, but git operations fail with "Authentication failed". bin/doctor warns about missing variable.
* [x] Bring up the server with GIT_BRIDGE_ENABLED=true and with a value in GIT_BRIDGE_OAUTH2_CLIENT_SECRET. The server starts. The Git feature is visible in the UI and is functional.