### PR TITLE
Ensure git bridge is disabled by default

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -345,7 +345,7 @@ function check_config_files() {
           print_point 2 "SHARELATEX_HISTORY_BACKEND: fs"
         fi
 
-        if [[ -n ${GIT_BRIDGE_ENABLED:-} ]]; then
+        if [[ ${GIT_BRIDGE_ENABLED:-false} = true ]]; then
           if [[ -n ${GIT_BRIDGE_OAUTH2_CLIENT_SECRET:-} ]]; then
             print_point 2 "GIT_BRIDGE_OAUTH2_CLIENT_SECRET: [set here]"
           else

--- a/lib/config-seed/overleaf.rc
+++ b/lib/config-seed/overleaf.rc
@@ -27,7 +27,7 @@ REDIS_DATA_PATH=data/redis
 #
 # If you enable git bridge, you must also set GIT_BRIDGE_OAUTH2_CLIENT_SECRET
 # in variables.env
-GIT_BRIDGE_ENABLED=true
+GIT_BRIDGE_ENABLED=false
 GIT_BRIDGE_DATA_PATH=data/git-bridge
 
 # TLS proxy configuration (optional)


### PR DESCRIPTION
## Description

The config seed was mistakenly setting the GIT_BRIDGE_ENABLED variable to true rather than false. We want git bridge to be enabled manually because users also have to set a secret for it to work correctly.

I also changed bin/doctor so that it explicitly looked for GIT_BRIDGE_ENABLED=true rather than just looking whether it had been set.