### PR TITLE
Add -subj option to openssl req command

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -51,7 +51,7 @@ function set_up_tls_proxy() {
   echo "Generate example self-signed TLS cert"
   mkdir -p config/nginx/certs
   cp "$TOOLKIT_ROOT/lib/config-seed/nginx.conf" "$TOOLKIT_ROOT/config/nginx/"
-  openssl req -new -nodes -keyout "$PRIVATE_KEY" -out "$CERT_SIGN_REQ" -batch
+  openssl req -new -nodes -keyout "$PRIVATE_KEY" -out "$CERT_SIGN_REQ" -subj "/CN=example.com" -batch
   chmod 600 "$PRIVATE_KEY"
   openssl x509 -req -days 365 -in "$CERT_SIGN_REQ"  -signkey "$PRIVATE_KEY" -out "$CERT"
 }


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

When running `bin/init --tls` as described in [the TLS Proxy instructions](https://github.com/overleaf/toolkit/blob/master/doc/tls-proxy.md), `openssl req` on macOS (LibreSSL 3.3.6) fails with "error, no objects specified in config file". The config can also be provided as options on the command line, and adding `-subj "/CN=example.com"` is enough to make the command (which is only generating example files) succeed. 

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
