### PR TITLE
Pass the Host header through nginx

### DIFF
--- a/lib/config-seed/nginx.conf
+++ b/lib/config-seed/nginx.conf
@@ -35,6 +35,7 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_read_timeout 3m;
             proxy_send_timeout 3m;


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

As noted in https://github.com/overleaf/overleaf/issues/1096, the subdomain mappings specified in `SHARELATEX_LANG_DOMAIN_MAPPING` only affect the language if the `Host` header is passed through the nginx proxy to the web service.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

closes https://github.com/overleaf/overleaf/issues/1096
refs https://github.com/overleaf/overleaf/pull/896

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
