### PR TITLE
Start Mongo in a replica set by default

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck source-path=..
 
 set -euo pipefail
 
@@ -15,14 +16,11 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
   exit 1
 fi
 
+source "$TOOLKIT_ROOT/lib/shared-functions.sh"
+
 function __main__() {
-  local IMAGE_VERSION
-  IMAGE_VERSION="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
-  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-RC)?$ ]]; then
-    echo "ERROR: invalid version '${IMAGE_VERSION}'"
-    exit 1
-  fi
-  local IMAGE_VERSION_MAJOR=${BASH_REMATCH[1]}
+  # Load the Overleaf version
+  read_image_version
 
   # Load vars from the rc file
   read_config
@@ -34,6 +32,11 @@ function __main__() {
   fi
   if [[ "$MONGO_ENABLED" == "true" ]]; then
     compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.mongo.yml")
+    if [[ "${IMAGE_VERSION_MAJOR}" -ge 4 ]]; then
+      MONGO_ARGS="--replSet overleaf"
+    else
+      MONGO_ARGS=""
+    fi
   fi
   if [[ "$SIBLING_CONTAINERS_ENABLED" == "true" ]]; then
     compose_file_flags+=("-f $TOOLKIT_ROOT/lib/docker-compose.sibling-containers.yml")
@@ -106,6 +109,7 @@ function __main__() {
   export GIT_BRIDGE_ENABLED
   export GIT_BRIDGE_IMAGE
   export IMAGE="$full_image_spec"
+  export MONGO_ARGS
   export MONGO_DATA_PATH
   export MONGO_IMAGE
   export MONGO_URL
@@ -127,13 +131,6 @@ function __main__() {
 
   # shellcheck disable=SC2068
   exec docker-compose -p "$PROJECT_NAME" ${compose_file_flags[@]} "$@"
-}
-
-function read_config () {
-  # shellcheck source=../lib/default.rc
-  source "$TOOLKIT_ROOT/lib/default.rc"
-  # shellcheck source=/dev/null
-  source "$TOOLKIT_ROOT/config/overleaf.rc"
 }
 
 __main__ "$@"

--- a/bin/up
+++ b/bin/up
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck source-path=..
 
 set -euo pipefail
 
@@ -14,6 +15,8 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
   echo "ERROR: could not find root of overleaf-toolkit project (inferred project root as '$TOOLKIT_ROOT')"
   exit 1
 fi
+
+source "$TOOLKIT_ROOT/lib/shared-functions.sh"
 
 function usage() {
   echo "Usage: bin/up [FLAGS...]"
@@ -32,12 +35,31 @@ function check_config() {
   fi
 }
 
+function initiate_mongo_replica_set() {
+  echo "Initiating Mongo replica set..."
+  "$TOOLKIT_ROOT/bin/docker-compose" up -d mongo
+  "$TOOLKIT_ROOT/bin/docker-compose" exec -T mongo sh -c '
+    while ! mongo --eval "db.version()" > /dev/null; do
+      echo "Waiting for Mongo..."
+      sleep 1
+    done
+    mongo --eval "rs.initiate({ _id: \"overleaf\", members: [ { _id: 0, host: \"mongo:27017\" } ] })" > /dev/null'
+}
+
 function __main__() {
   if [[ "${1:-null}" == "help" ]] || [[ "${1:-null}" == "--help" ]]; then
     usage
     exit
   fi
+
   check_config
+  read_config
+  read_image_version
+
+  if [[ "$MONGO_ENABLED" == "true" && "$IMAGE_VERSION_MAJOR" -ge 4 ]]; then
+    initiate_mongo_replica_set
+  fi
+
   exec "$TOOLKIT_ROOT/bin/docker-compose" up "$@"
 }
 

--- a/lib/docker-compose.mongo.yml
+++ b/lib/docker-compose.mongo.yml
@@ -5,6 +5,7 @@ services:
     mongo:
         restart: always
         image: "${MONGO_IMAGE}"
+        command: "${MONGO_ARGS}"
         container_name: mongo
         volumes:
             - "${MONGO_DATA_PATH}:/data/db"

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck source-path=..
+
+function read_config() {
+  source "$TOOLKIT_ROOT/lib/default.rc"
+  # shellcheck source=/dev/null
+  source "$TOOLKIT_ROOT/config/overleaf.rc"
+}
+
+function read_image_version() {
+  IMAGE_VERSION="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
+  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-RC)?$ ]]; then
+    echo "ERROR: invalid version '${IMAGE_VERSION}'"
+    exit 1
+  fi
+  IMAGE_VERSION_MAJOR=${BASH_REMATCH[1]}
+}


### PR DESCRIPTION
## Description

Starting with Overleaf CE/ServerPro version 4, Mongo needs to be in a replica set. By default, the replica set is made of a single instance.

The replica set needs to be initiated once, and it doesn't hurt if it gets initiated more than once. In this PR, I initiate the replica set in the `bin/up` script.

I needed some functions from `bin/docker-compose` in `bin/up`, so I started a shared library of bash functions.

### Manual testing performed

* [x] Started ServerPro 3.5.5 - verified that it didn't run Mongo in a replica set
* [x] Started the upcoming ServerPro 4.0.0 - verified that it ran Mongo in a replica set
* [x] Checked that project history worked
