### PR TITLE
Change the location of the git-bridge data directory

### DIFF
--- a/lib/docker-compose.git-bridge.yml
+++ b/lib/docker-compose.git-bridge.yml
@@ -6,14 +6,15 @@ services:
         restart: always
         image: "${GIT_BRIDGE_IMAGE}"
         volumes:
-            - "${GIT_BRIDGE_DATA_PATH}:/tmp/wlgb"
+            - "${GIT_BRIDGE_DATA_PATH}:/data/git-bridge"
         container_name: git-bridge
         expose:
             - "8000"
         environment:
-          GIT_BRIDGE_API_BASE_URL: "http://sharelatex/api/v0"
-          GIT_BRIDGE_OAUTH2_SERVER: "http://sharelatex"
-          GIT_BRIDGE_POSTBACK_BASE_URL: "http://git-bridge:8000"
+            GIT_BRIDGE_API_BASE_URL: "http://sharelatex/api/v0"
+            GIT_BRIDGE_OAUTH2_SERVER: "http://sharelatex"
+            GIT_BRIDGE_POSTBACK_BASE_URL: "http://git-bridge:8000"
+            GIT_BRIDGE_ROOT_DIR: "/data/git-bridge"
         env_file:
             - common.env
             - ../config/variables.env


### PR DESCRIPTION
## Description

The default location of the data directory inside the git-bridge container is /tmp/wlgb, but the data it contains should not be considered temporary. In order to avoid any misunderstanding that would lead an administrator to delete the contents of the /tmp directory, we move the data directory to /data/git-bridge.

## Manual testing

- [x] Checked that an existing git-bridge data directory was correctly mounted
- [x] Checked that the directory was created if it didn't exist yet