### PR TITLE
Removed OAuth2 client configuration

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -353,14 +353,6 @@ function check_config_files() {
         else
           print_point 2 "SHARELATEX_HISTORY_BACKEND: fs"
         fi
-
-        if [[ ${GIT_BRIDGE_ENABLED:-false} = true ]]; then
-          if [[ -n ${GIT_BRIDGE_OAUTH2_CLIENT_SECRET:-} ]]; then
-            print_point 2 "GIT_BRIDGE_OAUTH2_CLIENT_SECRET: [set here]"
-          else
-            add_warning "GIT_BRIDGE_OAUTH2_CLIENT_SECRET is missing in variables.env"
-          fi
-        fi
       fi
     fi
   done

--- a/lib/common.env
+++ b/lib/common.env
@@ -1,1 +1,0 @@
-GIT_BRIDGE_OAUTH2_CLIENT_ID="overleaf-git-bridge"

--- a/lib/config-seed/overleaf.rc
+++ b/lib/config-seed/overleaf.rc
@@ -25,9 +25,6 @@ REDIS_DATA_PATH=data/redis
 REDIS_IMAGE=redis:6.2
 
 # Git-bridge configuration (Server Pro only)
-#
-# If you enable git bridge, you must also set GIT_BRIDGE_OAUTH2_CLIENT_SECRET
-# in variables.env
 GIT_BRIDGE_ENABLED=false
 GIT_BRIDGE_DATA_PATH=data/git-bridge
 

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -20,6 +20,5 @@ services:
           SHARELATEX_REDIS_HOST: "${REDIS_HOST}"
           V1_HISTORY_URL: "http://sharelatex:3100/api"
         env_file:
-            - common.env
             - ../config/variables.env
         stop_grace_period: 60s

--- a/lib/docker-compose.git-bridge.yml
+++ b/lib/docker-compose.git-bridge.yml
@@ -16,7 +16,6 @@ services:
             GIT_BRIDGE_POSTBACK_BASE_URL: "http://git-bridge:8000"
             GIT_BRIDGE_ROOT_DIR: "/data/git-bridge"
         env_file:
-            - common.env
             - ../config/variables.env
         user: root
         command: ["/server-pro-start.sh"]


### PR DESCRIPTION
## Description

Now that the git bridge exclusively uses personal access tokens in ServerPro, it doesn't need to perform a password grant request and therefore doesn't need to have its OAuth client id and secret configured. This simplifies setup as it doesn't require the admin to add a secret to config/variables.env

## Manual testing

I tested that cloning a project still worked after removing the `GIT_BRIDGE_OAUTH2_CLIENT_SECRET` variable from config/variables.env and I checked that `bin/doctor` was happy as well.
