### PR TITLE
Allow "-with-texlive-full" suffix in version

### DIFF
--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -10,7 +10,7 @@ function read_config() {
 
 function read_image_version() {
   IMAGE_VERSION="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
-  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-RC)?$ ]]; then
+  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-RC)?(-with-texlive-full)?$ ]]; then
     echo "ERROR: invalid version '${IMAGE_VERSION}'"
     exit 1
   fi


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

This PR extends the schema of allowed Server Pro versions to include a suffix of "-with-texlive-full". I will [tweak the instructions for persisting the "sharelatex" container after upgrading texlive full](https://github.com/overleaf/overleaf/wiki/Quick-Start-Guide#latex-environment) once the PR has been merged.
