### PR TITLE
Add support for numbered release candidates like 4.1.0-RC1/4.1.0-RC2

### DIFF
--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -10,7 +10,7 @@ function read_config() {
 
 function read_image_version() {
   IMAGE_VERSION="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
-  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-RC)?(-with-texlive-full)?$ ]]; then
+  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-RC[0-9]*)?(-with-texlive-full)?$ ]]; then
     echo "ERROR: invalid version '${IMAGE_VERSION}'"
     exit 1
   fi


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

This PR is extending the scheme of accepted `config/version` values to account for more than one release candidate.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
