### PR TITLE
Use web-api for git-bridge in Server Pro 4.2.0 onwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2023-09-18
+
+### Added
+- Prepare for addition of web-api service in upcoming Server Pro 4.2 release.
+
 ## 2023-09-06
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `4.1.1`.

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -77,6 +77,13 @@ function set_base_vars() {
     GIT_BRIDGE_ENABLED=false
   fi
 
+  HAS_WEB_API=false
+  if [[ $IMAGE_VERSION_MAJOR -gt 4 ]]; then
+    HAS_WEB_API=true
+  elif [[ $IMAGE_VERSION_MAJOR == 4 && $IMAGE_VERSION_MINOR -ge 2 ]]; then
+    HAS_WEB_API=true
+  fi
+
   export GIT_BRIDGE_ENABLED
   export MONGO_URL
   export REDIS_HOST
@@ -146,7 +153,14 @@ function set_git_bridge_vars() {
   else
     image_name="quay.io/sharelatex/git-bridge:$IMAGE_VERSION"
   fi
+
+  GIT_BRIDGE_API_BASE_URL="http://sharelatex/api/v0/"
+  if [[ $HAS_WEB_API == "true" ]]; then
+    GIT_BRIDGE_API_BASE_URL="http://sharelatex:3000/api/v0/"
+  fi
+
   DOCKER_COMPOSE_FLAGS+=(-f "$TOOLKIT_ROOT/lib/docker-compose.git-bridge.yml")
+  export GIT_BRIDGE_API_BASE_URL
   export GIT_BRIDGE_IMAGE=${image_name}
   export GIT_BRIDGE_DATA_PATH
   export GIT_BRIDGE_LOG_LEVEL

--- a/lib/docker-compose.git-bridge.yml
+++ b/lib/docker-compose.git-bridge.yml
@@ -11,7 +11,7 @@ services:
         expose:
             - "8000"
         environment:
-            GIT_BRIDGE_API_BASE_URL: "http://sharelatex/api/v0"
+            GIT_BRIDGE_API_BASE_URL: "${GIT_BRIDGE_API_BASE_URL}"
             GIT_BRIDGE_OAUTH2_SERVER: "http://sharelatex"
             GIT_BRIDGE_POSTBACK_BASE_URL: "http://git-bridge:8000"
             GIT_BRIDGE_ROOT_DIR: "/data/git-bridge"

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -10,9 +10,10 @@ function read_config() {
 
 function read_image_version() {
   IMAGE_VERSION="$(head -n 1 "$TOOLKIT_ROOT/config/version")"
-  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+(-RC[0-9]*)?(-with-texlive-full)?$ ]]; then
+  if [[ ! "$IMAGE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+(-RC[0-9]*)?(-with-texlive-full)?$ ]]; then
     echo "ERROR: invalid version '${IMAGE_VERSION}'"
     exit 1
   fi
   IMAGE_VERSION_MAJOR=${BASH_REMATCH[1]}
+  IMAGE_VERSION_MINOR=${BASH_REMATCH[2]}
 }


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Part of: https://github.com/overleaf/internal/issues/7394
Sibling of https://github.com/overleaf/internal/pull/14857

This PR is adjusting the contents of `GIT_BRIDGE_API_BASE_URL` for Server Pro 4.2 onwards to talk to web-api.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Part of: https://github.com/overleaf/internal/issues/7394
Sibling of https://github.com/overleaf/internal/pull/14857

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
