### PR TITLE
Add full project history services to bin scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2023-10-24
+### Added
+- `bin/logs`: Pick up logs from history-v1 and project-history
+
 ## 2023-10-06
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `4.1.3`.

--- a/bin/error-logs
+++ b/bin/error-logs
@@ -20,7 +20,7 @@ function usage() {
     echo ""
     echo "Services:  chat, clsi, contacts, docstore, document-updater,"
     echo "           filestore, notifications, real-time, spelling,"
-    echo "           tags, track-changes, web"
+    echo "           tags, track-changes, web, project-history, history-v1"
     echo ""
     echo "Options:"
     echo "  -f              follow log output"

--- a/bin/logs
+++ b/bin/logs
@@ -17,7 +17,8 @@ fi
 
 DEFAULT_TAIL_LINES=20
 ALL_SERVICES=(chat clsi contacts docstore document-updater filestore git-bridge \
-    mongo notifications real-time redis spelling tags track-changes web)
+    mongo notifications real-time redis spelling tags track-changes web \
+    history-v1 project-history)
 
 LOGS_PID_FILE="/tmp/toolkit-logs.$$.pid"
 
@@ -26,7 +27,7 @@ function usage() {
 
 Services:  chat, clsi, contacts, docstore, document-updater, filestore,
            git-bridge, mongo, notifications, real-time, redis, spelling,
-           tags, track-changes, web
+           tags, track-changes, web, history-v1, project-history
 
 Options:
   -f              follow log output


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

This PR lets `bin/logs -f` pick up history-v1/project-history logs.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

https://github.com/overleaf/internal/pull/15410

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
