### PR TITLE
Warning when running bin/upgrade with custom docker image

### DIFF
--- a/bin/upgrade
+++ b/bin/upgrade
@@ -118,6 +118,18 @@ function handle_image_upgrade() {
 
   echo "Upgrading config/version from $user_image_version to $seed_image_version"
 
+  local docker_compose_override_path="$TOOLKIT_ROOT/config/docker-compose.override.yml"
+  if [ -f "$docker_compose_override_path" ]; then
+     if grep -E '^\s*image: sharelatex/sharelatex.*' "$docker_compose_override_path"; then
+        echo "WARNING: you are using a customized docker image, the server may not run on the latest version post upgrade."
+        echo "* If you have followed the guide 'Upgrading TexLive', please remove and recreate the modified image."
+        echo "* Remove the image: 'docker rm sharelatex/sharelatex:with-texlive-full'"
+        echo "* Remove the override file: 'rm config/docker-compose.override.yml'"
+        echo "* Recreate the image by following: https://github.com/overleaf/toolkit/blob/master/doc/ce-upgrading-texlive.md"
+     fi
+  fi
+
+
   ## Offer to stop docker services
   local services_stopped="false"
   if services_up; then

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -120,7 +120,7 @@ function handle_image_upgrade() {
 
   local docker_compose_override_path="$TOOLKIT_ROOT/config/docker-compose.override.yml"
   if [ -f "$docker_compose_override_path" ]; then
-     if grep -E '^\s*image: sharelatex/sharelatex.*' "$docker_compose_override_path"; then
+     if grep -q -E '^\s*image: sharelatex/sharelatex.*' "$docker_compose_override_path"; then
         echo "WARNING: you are using a customized docker image, the server may not run on the latest version post upgrade."
         echo "* If you have followed the guide 'Upgrading TexLive', please remove and recreate the modified image."
         echo "* Remove the image: 'docker rm sharelatex/sharelatex:with-texlive-full'"


### PR DESCRIPTION
## Description
Alert the user if they attempt to run `bin/upgrade` while having a custom Docker image specified in `config/docker-compose.override.yml` . 

The container will not upgrade when a customized image is specified. This issue can happen if the user creates a`sharelatex/sharelatex:with-texlive-full` image by following this guide: [ce-upgrading-texlive](https://github.com/overleaf/toolkit/blob/master/doc/ce-upgrading-texlive.md). The upgrade procedure can complete normally but the application will still run on an older version.

### This pull request adds following features:

The updated script will first find and match the line `image: sharelatex/sharelatex.*` inside `config/docker-compose.override.yml`. If the line exists, print warnings.

The warning message is as followed:
```text
WARNING: you are using a customized docker image, the server may not run on the latest version post upgrade.
* If you have followed the guide 'Upgrading TexLive', please remove and recreate the modified image.
* Remove the image: 'docker rm sharelatex/sharelatex:with-texlive-full'
* Remove the override file: 'rm config/docker-compose.override.yml'
* Recreate the image by following: https://github.com/overleaf/toolkit/blob/master/doc/ce-upgrading-texlive.md
``` 


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
