### PR TITLE
Docs: Fix link to doc/ directory on GitHub

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -64,4 +64,4 @@ The `bin/` directory contains a collection of scripts, which will be your main i
 
 ### Documentation
 
-You will find all of the documentation you need in the `doc/` directory. This documentation can also be viewed online, here: https://github.com/overleaf/toolkit/tree/master/doc/_index.md
+You will find all the documentation you need in the `doc/` directory. This documentation can also be viewed online, here: https://github.com/overleaf/toolkit/tree/master/doc/


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

There is no `_index.md` file in the doc/ folder.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Closes https://github.com/overleaf/toolkit/pull/213

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
