### PR TITLE
Remove ShareLaTeX branding from in-container mount target

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -84,12 +84,18 @@ function set_base_vars() {
     HAS_WEB_API=true
   fi
 
+  OVERLEAF_IN_CONTAINER_DATA_PATH=/var/lib/overleaf
+  if [[ "$IMAGE_VERSION_MAJOR" -lt 5 ]]; then
+    OVERLEAF_IN_CONTAINER_DATA_PATH=/var/lib/sharelatex
+  fi
+
   export GIT_BRIDGE_ENABLED
   export MONGO_URL
   export REDIS_HOST
   export REDIS_PORT
   export OVERLEAF_DATA_PATH
   export OVERLEAF_PORT
+  export OVERLEAF_IN_CONTAINER_DATA_PATH
 }
 
 # Set environment variables for docker-compose.redis.yml

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -7,7 +7,7 @@ services:
         image: "${IMAGE}"
         container_name: sharelatex
         volumes:
-            - "${OVERLEAF_DATA_PATH}:/var/lib/sharelatex"
+            - "${OVERLEAF_DATA_PATH}:${OVERLEAF_IN_CONTAINER_DATA_PATH}"
         ports:
             - "${OVERLEAF_LISTEN_IP:-127.0.0.1}:${OVERLEAF_PORT:-80}:80"
         environment:


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Part of https://github.com/overleaf/internal/issues/12587

This PR is migrating the in-container bind-mount target from ShareLaTeX branded path to the Overleaf branded equivalent.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Part of https://github.com/overleaf/internal/issues/12587

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
