### PR TITLE
Remove old fix for LuaLaTeX -- this is baked into Server Pro 3.2 onwards

### DIFF
--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -8,10 +8,6 @@ ENABLE_CONVERSIONS=true
 # Disables email confirmation requirement
 EMAIL_CONFIRMATION_DISABLED=true
 
-# temporary fix for LuaLaTex compiles
-# see https://github.com/overleaf/overleaf/issues/695
-TEXMFVAR=/var/lib/sharelatex/tmp/texmf-var
-
 ## Nginx
 # NGINX_WORKER_PROCESSES=4
 # NGINX_WORKER_CONNECTIONS=768


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

I think it's time to remove the config hack from 2020. Any releases from 3.2 onwards will have the env var baked in: https://github.com/overleaf/overleaf/pull/739.

I think it's OK to temporarily break LuaLaTeX for compiles when customers upgrade the toolkit in a <3.2 setup (which is not supported anymore, for anything other than performing an upgrade).

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

https://github.com/overleaf/overleaf/pull/739

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
