### PR TITLE
Provide fallback to ShareLaTeX branded rc entry in 4.x setups

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -65,12 +65,14 @@ function set_base_vars() {
   fi
   export IMAGE="$image_name:$IMAGE_VERSION"
 
+  OVERLEAF_LISTEN_IP=${OVERLEAF_LISTEN_IP:-${SHARELATEX_LISTEN_IP:-}}
   if [[ ${OVERLEAF_LISTEN_IP:-null} == "null" ]];
   then
     echo "WARNING: the value of OVERLEAF_LISTEN_IP is not set in config/overleaf.rc. This value must be set to the public IP address for direct container access. Defaulting to 0.0.0.0" >&2
     OVERLEAF_LISTEN_IP="0.0.0.0"
   fi
   export OVERLEAF_LISTEN_IP
+  OVERLEAF_PORT=${OVERLEAF_PORT:-${SHARELATEX_PORT:-}}
 
   if [[ $SERVER_PRO != "true" || $IMAGE_VERSION_MAJOR -lt 4 ]]; then
     # Force git bridge to be disabled if not ServerPro >= 4


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Small fix for https://github.com/overleaf/toolkit/pull/217

The rc file has the old branding on the core variables `SHARELATEX_LISTEN_IP` and `SHARELATEX_PORT`. After rebanding the rc entry we still need to fallback to the old ones for customers using the latest toolkit version with a 4.x release.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

For https://github.com/overleaf/toolkit/pull/217

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
