### PR TITLE
Relaunch bin/upgrade after pulling changes via git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 
   We are planning to expand the scope of the `bin/upgrade` script in a following release and these changes need to be applied _while_ running `bin/upgrade`.
 
-  Please restart `bin/upgrade` manually after fetching this code update.
-  After confirming "Perform code update?", please choose "n" at the next prompt "Upgrade image?".
+  With this release there is a one-time requirement that you choose "Yes" to "Perform code update?" and "No" to "Upgrade image?". After the Toolkit code has been updated, run `bin/upgrade` again and choose to upgrade the image.
 
 ## 2024-02-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2024-02-27
+### Fixed
+
+- Relaunch `bin/upgrade` after updating Toolkit code.
+
+  We are planning to expand the scope of the `bin/upgrade` script in a following release and these changes need to be applied _while_ running `bin/upgrade`.
+
+  Please restart `bin/upgrade` manually after fetching this code update.
+  After confirming "Perform code update?", please choose "n" at the next prompt "Upgrade image?".
+
 ## 2024-02-16
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `4.2.3`.

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -218,6 +218,8 @@ function handle_git_update() {
       echo "Current commit is $current_commit"
       echo "Updating code..."
       git -C "$TOOLKIT_ROOT" pull origin "$current_branch"
+      echo "Relaunching bin/upgrade after code update"
+      exec $0 --skip-git-update
     fi
   fi
 }
@@ -228,7 +230,11 @@ function __main__() {
     usage && exit
   fi
 
-  handle_git_update
+  if [[ "${1:-null}" == "--skip-git-update" ]]; then
+    echo "Skipping git update"
+  else
+    handle_git_update
+  fi
 
   read_seed_image_version
   read_image_version


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

This will enable us to make changes to `bin/upgrade` and get them applied for the next "upgrade". It will likely not help this time around, but it will help the next time we make changes to `bin/upgrade`.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Part of https://github.com/overleaf/internal/issues/15476
For https://github.com/overleaf/toolkit/pull/217

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
