### PR TITLE
Disable IPv6 for sharelatex container

### DIFF
--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -6,6 +6,8 @@ services:
         restart: always
         image: "${IMAGE}"
         container_name: sharelatex
+        sysctls:
+            - net.ipv6.conf.all.disable_ipv6=1
         volumes:
             - "${SHARELATEX_DATA_PATH}:/var/lib/sharelatex"
         ports:


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
For me, there was an issue where sharelatex/nginx were trying to use 127.0.0.1 to access the proxied services, but some were only listening on ::1, and one seemed to be listening on ::1 but redirect to 127.0.0.1. To make things consistent, I disabled IPv6 in that container to ensure they all use 127.0.0.1. An alternative solution would be to make all config references consistent (127.0.0.1 vs "localhost", which may resolve to ::1), but this seems simpler and IPv6 is unlikely to be needed for the internal Docker network in this case.

## Related issues / Pull Requests
None


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
