### PR TITLE
remove version in the docker compose file

### DIFF
--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -1,5 +1,4 @@
 ---
-version: '2.2'
 services:
 
     sharelatex:


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
remove version in the docker compose file

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
latest docker would report, this PR address this warning
```
"WARN[0000] overleaf-toolkit/lib/docker-compose.base.yml: `version` is obsolete"
```

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
