### PR TITLE
remove version in the docker compose file

### DIFF
--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+
 services:
 
     sharelatex:

--- a/lib/docker-compose.git-bridge.yml
+++ b/lib/docker-compose.git-bridge.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+
 services:
 
     git-bridge:

--- a/lib/docker-compose.mongo.yml
+++ b/lib/docker-compose.mongo.yml
@@ -1,5 +1,4 @@
 ---
-version: '2.2'
 services:
 
     mongo:

--- a/lib/docker-compose.nginx.yml
+++ b/lib/docker-compose.nginx.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+
 services:
 
   nginx:

--- a/lib/docker-compose.redis.yml
+++ b/lib/docker-compose.redis.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+
 services:
 
     redis:

--- a/lib/docker-compose.sibling-containers.yml
+++ b/lib/docker-compose.sibling-containers.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.2'
+
 services:
   sharelatex:
     volumes:


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
remove version in the docker compose file

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
latest docker would report, this PR address this warning
```
"WARN[0000] overleaf-toolkit/lib/docker-compose.base.yml: `version` is obsolete"
```

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
