### PR TITLE
bin/images: Add header to docker images output

### DIFF
--- a/bin/images
+++ b/bin/images
@@ -29,11 +29,11 @@ function __main__() {
     fi
 
     echo "---- Community Edition Images ----"
-    docker images | grep '^sharelatex/sharelatex\s'
+    docker images sharelatex/sharelatex
     echo "---- Server Pro Images ----"
-    docker images | grep '^quay.io/sharelatex/sharelatex-pro\s'
+    docker images quay.io/sharelatex/sharelatex-pro
     echo "---- TexLive Images ----"
-    docker images | grep '^quay.io/sharelatex/texlive'
+    docker images quay.io/sharelatex/texlive-full
 }
 
 __main__ "$@"


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

This PR is making the output of `bin/images` easier to read by adding the `REPOSITORY  TAG  IMAGE ID  CREATED  SIZE` header and reducing the width of the output (previously, unrelated long repository names or tag names would impact the output of the grepped lines).

Before:
```
toolkit$ bin/images 
---- Community Edition Images ----
sharelatex/sharelatex                                          5.0.0-RC3                                                                      d6574de1e3f1   5 weeks ago     2.83GB
``` 

After:
```
toolkit$ bin/images 
---- Community Edition Images ----
REPOSITORY              TAG            IMAGE ID       CREATED         SIZE
sharelatex/sharelatex   5.0.0-RC3      d6574de1e3f1   5 weeks ago     2.83GB
```

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

For https://github.com/overleaf/toolkit/pull/226

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
