### PR TITLE
Remove "Powered by Overleaf" entry from default left footer

### DIFF
--- a/lib/config-seed/variables.env
+++ b/lib/config-seed/variables.env
@@ -21,8 +21,8 @@ EMAIL_CONFIRMATION_DISABLED=true
 # OVERLEAF_HEADER_IMAGE_URL=http://somewhere.com/mylogo.png
 # OVERLEAF_ADMIN_EMAIL=support@example.com
 
-# OVERLEAF_LEFT_FOOTER=[{"text":"Powered by Overleaf © 2021", "url": "https://www.overleaf.com"}, {"text": "Contact your support team", "url": "mailto:support@example.com"} ]
-# OVERLEAF_RIGHT_FOOTER=[{"text":"Hello I am on the Right"}]
+# OVERLEAF_LEFT_FOOTER='[{"text": "Contact your support team", "url": "mailto:support@example.com"}]'
+# OVERLEAF_RIGHT_FOOTER='[{"text": "Hello, I am on the Right"}]'
 
 # OVERLEAF_EMAIL_FROM_ADDRESS=team@example.com
 


### PR DESCRIPTION

## Description
<!-- Goal of the pull request -->

This PR is removing the "Powered by Overleaf" entry from the default left footer. The item is part of the pug template now.

Also add single quotes to help "source" with loading the entries.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Recent support case

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
