### PR TITLE
Update retraction of Server Pro 5.0.1

### DIFF
--- a/bin/upgrade
+++ b/bin/upgrade
@@ -120,6 +120,7 @@ function handle_image_upgrade() {
 
   if [[ ! "$should_upgrade" =~ [Yy] ]]; then
     echo "Keeping image version '$IMAGE_VERSION'"
+    check_retracted_version
     return 0
   fi
 
@@ -136,6 +137,24 @@ function handle_image_upgrade() {
      fi
   fi
 
+
+  # Skip retraction check in sub-shells
+  export OVERLEAF_SKIP_RETRACTION_CHECK="$IMAGE_VERSION"
+  local version="$IMAGE_VERSION_MAJOR.$IMAGE_VERSION_MINOR.$IMAGE_VERSION_PATCH"
+  if [[ "$version" == "5.0.1" ]]; then
+    echo "-------------------------------------------------------"
+    echo "---------------------  WARNING  -----------------------"
+    echo "-------------------------------------------------------"
+    echo "  You are currently using a retracted version, $version."
+    echo ""
+    echo "  We have identified a critical bug in a database migration that causes data loss in the history system."
+    echo "  Please follow the steps of the recovery process in the following wiki page:"
+    echo "  https://github.com/overleaf/overleaf/wiki/Doc-version-recovery"
+    echo "-------------------------------------------------------"
+    echo "---------------------  WARNING  -----------------------"
+    echo "-------------------------------------------------------"
+    prompt "Are you following the recovery process?"
+  fi
 
   ## Offer to stop docker services
   local services_stopped="false"
@@ -241,7 +260,6 @@ function __main__() {
 
   read_seed_image_version
   read_image_version
-  check_retracted_version
   handle_rc_rebranding
   handle_image_upgrade
 

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -20,6 +20,10 @@ function read_image_version() {
 }
 
 function check_retracted_version() {
+  if [[ "${OVERLEAF_SKIP_RETRACTION_CHECK:-null}" == "$IMAGE_VERSION" ]]; then
+    return
+  fi
+
   local version="$IMAGE_VERSION_MAJOR.$IMAGE_VERSION_MINOR.$IMAGE_VERSION_PATCH"
   if [[ "$version" == "5.0.1" ]]; then
     echo "-------------------------------------------------------"
@@ -27,11 +31,10 @@ function check_retracted_version() {
     echo "-------------------------------------------------------"
     echo "  You are currently using a retracted version, $version."
     echo ""
-    echo "  We have identified a critical bug in a database migration that causes data loss."
-    echo "  Please defer upgrading to release 5.0.1 until further notice on the mailing list."
-    echo "  Please keep any backups that were taken prior to upgrading to version 5.0.1."
-    echo "  Updates will be posted in the release notes:"
-    echo "  https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#server-pro-501-retracted"
+    echo "  We have identified a critical bug in a database migration that causes data loss in the history system."
+    echo "  A new release is available with a fix and an automated recovery process."
+    echo "  Please follow the steps of the recovery process in the following wiki page:"
+    echo "  https://github.com/overleaf/overleaf/wiki/Doc-version-recovery"
     echo "-------------------------------------------------------"
     echo "---------------------  WARNING  -----------------------"
     echo "-------------------------------------------------------"


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Follow up for #240 
Part of https://github.com/overleaf/internal/issues/18037

This PR is updating the retraction message for 5.0.1 and letting `bin/upgrade` complete an upgrade to 5.0.2.

Warn when staying on 5.0.1
```
toolkit$ bin/upgrade 
Warning: current branch is not master, 'jpa-ease-retraction' instead
Checking for code update...
No code update available for download
New docker image version available (5.0.2)
Current image version is '5.0.1' (from config/version)
Upgrade image? [y/n] n
Keeping image version '5.0.1'
-------------------------------------------------------
---------------------  WARNING  -----------------------
-------------------------------------------------------
  You are currently using a retracted version, 5.0.1.

  We have identified a critical bug in a database migration that causes data loss in the history system.
  A new release is available with a fix and an automated recovery process.
  Please follow the steps of the recovery process in the following wiki page:
  https://github.com/overleaf/overleaf/wiki/Doc-version-recovery
-------------------------------------------------------
---------------------  WARNING  -----------------------
-------------------------------------------------------
```

Allow upgrade, show prompt for recovery process and allow stopping of containers
```
toolkit$ bin/upgrade 
Warning: current branch is not master, 'jpa-ease-retraction' instead
Checking for code update...
No code update available for download
New docker image version available (5.0.2)
Current image version is '5.0.1' (from config/version)
Upgrade image? [y/n] y
Upgrading config/version from 5.0.1 to 5.0.2
-------------------------------------------------------
---------------------  WARNING  -----------------------
-------------------------------------------------------
  You are currently using a retracted version, 5.0.1.

  We have identified a critical bug in a database migration that causes data loss in the history system.
  Please follow the steps of the recovery process in the following wiki page:
  https://github.com/overleaf/overleaf/wiki/Doc-version-recovery
-------------------------------------------------------
---------------------  WARNING  -----------------------
-------------------------------------------------------
Are you following the recovery process? (y/n): y
docker services are up, stop them first?
Stop docker services? [y/n] y
Stopping docker services
[+] Stopping 3/3
 ✔ Container sharelatex  Stopped                                                                                                                                                                                                                                                    60.4s 
 ✔ Container mongo       Stopped                                                                                                                                                                                                                                                     0.8s 
 ✔ Container redis       Stopped                                                                                                                                                                                                                                                     0.4s 
At this point, we recommend backing up your data before proceeding
!! WARNING: Only do this while the docker services are stopped!!
Proceed with the upgrade? [y/n] y
Backing up old version file to config/__old-version
Over-writing config/version with 5.0.2
Start docker services again? [y/n] y
Starting docker services
[+] Running 3/3
 ✔ Container mongo       Healthy                                                                                                                                                                                                                                                     0.0s 
 ✔ Container redis       Started                                                                                                                                                                                                                                                     0.0s 
 ✔ Container sharelatex  Started                                                                                                                                                                                                                                                     0.0s 
Done
```

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Follow up for #240 
Part of https://github.com/overleaf/internal/issues/18037


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
