### PR TITLE
bin/doctor: warn about using docker installed via snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-05-08
+### Added
+- Add warning for using docker installing via `snap`.
+
 ## 2024-04-22
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.0.3`.

--- a/bin/doctor
+++ b/bin/doctor
@@ -140,6 +140,10 @@ function check_docker_daemon() {
   print_point 0 "Docker Daemon"
   if docker ps &>/dev/null;  then
     print_point 1 "status: up"
+
+    if docker info | grep -q -e '/var/snap/docker/common/var-lib-docker'; then
+      add_warning "Installing Docker via snap is not supported. The sandboxed compiles feature may not be available. Please follow the steps for installing Docker CE on https://docs.docker.com/engine/install/."
+    fi
   else
     print_point 1 "status: DOWN !"
     add_warning "Docker daemon is not running"

--- a/doc/sandboxed-compiles.md
+++ b/doc/sandboxed-compiles.md
@@ -2,7 +2,6 @@
 
 In Server Pro, it is possible to have each LaTeX project be compiled in a separate docker container, achieving sandbox isolation between projects. 
 
-
 ## How It Works
 
 When sandboxed compiles are enabled, the toolkit will mount the docker socket from the host into the overleaf container, so that the compiler service in the container can create new docker containers on the host. Then for each run of the compiler in each project, the LaTeX compiler service (CLSI) will do the following:
@@ -18,3 +17,5 @@ When sandboxed compiles are enabled, the toolkit will mount the docker socket fr
 In `config/overleaf.rc`, set `SIBLING_CONTAINERS_ENABLED=true`, and ensure that the `DOCKER_SOCKET_PATH` setting is set to the location of the docker socket on the host.
 
 The next time you start the docker services (with `bin/up`), the overleaf container will verify that it can communicate with docker on the host machine, and will pull the `texlive` image it requires to create the sandboxed compile containers. This process can take several minutes, and compiles will be un-available during this time.
+
+Note: We do not support running sandboxed compiles with Docker as installed via `snap`. Please follow the steps for installing Docker CE on https://docs.docker.com/engine/install/.


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Following the recent support case, let's warn about the usage of docker when installed via `snap`.

```
====== Warnings ======
! Installing Docker via snap is not supported. The sandboxed compiles feature may not be available. Please follow the steps for installing Docker CE on https://docs.docker.com/engine/install/.
====== End ======
```

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
