### PR TITLE
bin/up: pull TeX Live images before starting up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-05-27
+### Added
+- Pull TeX Live images from `bin/up`
+
 ## 2024-05-24
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.0.4`.

--- a/bin/up
+++ b/bin/up
@@ -46,6 +46,29 @@ function initiate_mongo_replica_set() {
     mongo --eval "rs.initiate({ _id: \"overleaf\", members: [ { _id: 0, host: \"mongo:27017\" } ] })" > /dev/null'
 }
 
+function pull_sandboxed_compiles() {
+  if [[ "${SIBLING_CONTAINERS_PULL:-true}" == "false" ]]; then
+    echo "Skipping pulling of TeX Live images"
+    return
+  fi
+  local images=$(read_variable "ALL_TEX_LIVE_DOCKER_IMAGES")
+  if [[ -z "$images" ]]; then
+    echo
+    echo "Please configure ALL_TEX_LIVE_DOCKER_IMAGES in $TOOLKIT_ROOT/config/variables.env"
+    echo
+    echo "You can read more about configuring Sandboxed Compiles in our documentation:"
+    echo "  https://github.com/overleaf/overleaf/wiki/Server-Pro:-sandboxed-compiles#changing-the-texlive-image"
+    echo
+    exit 1
+  fi
+  echo "Pulling TeX Live images..."
+  for image in ${images//,/ }; do
+    echo "  - $image download started (may take some time)"
+    docker pull $image
+    echo "  - $image download finished"
+  done
+}
+
 function __main__() {
   if [[ "${1:-null}" == "help" ]] || [[ "${1:-null}" == "--help" ]]; then
     usage
@@ -58,6 +81,10 @@ function __main__() {
 
   if [[ "$MONGO_ENABLED" == "true" && "$IMAGE_VERSION_MAJOR" -ge 4 ]]; then
     initiate_mongo_replica_set
+  fi
+
+  if [[ "$SIBLING_CONTAINERS_ENABLED" == "true" ]]; then
+    pull_sandboxed_compiles
   fi
 
   exec "$TOOLKIT_ROOT/bin/docker-compose" up "$@"

--- a/doc/sandboxed-compiles.md
+++ b/doc/sandboxed-compiles.md
@@ -16,6 +16,8 @@ When sandboxed compiles are enabled, the toolkit will mount the docker socket fr
 
 In `config/overleaf.rc`, set `SIBLING_CONTAINERS_ENABLED=true`, and ensure that the `DOCKER_SOCKET_PATH` setting is set to the location of the docker socket on the host.
 
-The next time you start the docker services (with `bin/up`), the overleaf container will verify that it can communicate with docker on the host machine, and will pull the `texlive` image it requires to create the sandboxed compile containers. This process can take several minutes, and compiles will be un-available during this time.
+The next time you start the docker services (with `bin/up`), the requested TeX Live image (`ALL_TEX_LIVE_DOCKER_IMAGES`) will get downloaded. This process can take several minutes. Once the images have been downloaded, the Server Pro container will get started with the latest configuration changes applied (such as enabling the Sandboxed Compiles feature or adding new TeX Live images).
+
+You can skip the download of images using `SIBLING_CONTAINERS_PULL=false` in `config/overleaf.rc`.
 
 Note: We do not support running sandboxed compiles with Docker as installed via `snap`. Please follow the steps for installing Docker CE on https://docs.docker.com/engine/install/.

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -125,3 +125,9 @@ function check_sharelatex_env_vars() {
     fi
   fi
 }
+
+function read_variable() {
+  local name=$1
+  grep -E "^$name=" "$TOOLKIT_ROOT/config/variables.env" \
+  | sed -r "s/^$name=([\"']*)(.+)\1*\$/\2/"
+}


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Part of https://github.com/overleaf/internal/issues/17497
Sibling for https://github.com/overleaf/internal/pull/18523

This PR is adding a startup step in `bin/up` to pull TeXLive images ahead of recreating/starting the container.

This will avoid the need to warn customers about compiles being unavailable for a while when enabling sandboxed compiles. cc @mlevans0 

```
toolkit$ bin/up sharelatex
Initiating Mongo replica set...
[+] Running 1/0
 ✔ Container mongo  Running                                                                                                                                                                                                                                                          0.0s 

Please configure ALL_TEX_LIVE_DOCKER_IMAGES in /code/overleaf/toolkit/config/variables.env

You can read more about configuring Sandboxed Compiles in our documentation:
  https://github.com/overleaf/overleaf/wiki/Server-Pro:-sandboxed-compiles#changing-the-texlive-image

toolkit$  echo $?
1 
```

```
toolkit$ bin/up --dry-run sharelatex
Initiating Mongo replica set...
[+] Running 1/0
 ✔ Container mongo  Running                                                                                                                                                                                                                                                          0.0s 
Pulling TeX Live images...
  - quay.io/sharelatex/texlive-full:2022.1 download started (may take some time)
2022.1: Pulling from sharelatex/texlive-full
Digest: sha256:4cc4060337c756c8df8f7b74e1138eebf557a68db70a57e222ccc808e2b4ab64
Status: Image is up to date for quay.io/sharelatex/texlive-full:2022.1
quay.io/sharelatex/texlive-full:2022.1
  - quay.io/sharelatex/texlive-full:2022.1 download finished
  - quay.io/sharelatex/texlive-full:2023.1 download started (may take some time)
2023.1: Pulling from sharelatex/texlive-full
Digest: sha256:395a3d79f858ace6fcbea1b4cfa5be343591413a1c4de01d8d329ed7389f455b
Status: Image is up to date for quay.io/sharelatex/texlive-full:2023.1
quay.io/sharelatex/texlive-full:2023.1
  - quay.io/sharelatex/texlive-full:2023.1 download finished
[+] Running 3/0
 ✔ DRY-RUN MODE -  Container mongo       Running
...
```

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Part of https://github.com/overleaf/internal/issues/17497
Sibling for https://github.com/overleaf/internal/pull/18523

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)

#### Manual testing performed

- missing entry
- single and double quotes