### PR TITLE
Add support for Mongo 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-07-16
+### Added
+- Added support for Mongo 6.0.
+
 ## 2024-07-12
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.0.7`.

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -123,7 +123,8 @@ function set_mongo_vars() {
   export MONGO_ARGS
 
   export MONGO_DATA_PATH
-  export MONGO_IMAGE
+  export MONGO_DOCKER_IMAGE
+  export MONGOSH
 }
 
 # Set environment variables for docker-compose.sibling-containers.yml
@@ -208,6 +209,7 @@ function docker_compose() {
 }
 
 read_image_version
+read_mongo_version
 read_config
 check_retracted_version
 check_sharelatex_env_vars

--- a/bin/mongo
+++ b/bin/mongo
@@ -15,8 +15,11 @@ if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
   exit 1
 fi
 
+source "$TOOLKIT_ROOT/lib/shared-functions.sh"
+
 function __main__() {
-  exec "$TOOLKIT_ROOT/bin/docker-compose" exec mongo mongo sharelatex
+  read_mongo_version
+  exec env SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" exec mongo $MONGOSH sharelatex
 }
 
 __main__ "$@"

--- a/bin/up
+++ b/bin/up
@@ -37,13 +37,13 @@ function check_config() {
 
 function initiate_mongo_replica_set() {
   echo "Initiating Mongo replica set..."
-  "$TOOLKIT_ROOT/bin/docker-compose" up -d mongo
-  "$TOOLKIT_ROOT/bin/docker-compose" exec -T mongo sh -c '
-    while ! mongo --eval "db.version()" > /dev/null; do
+  SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" up -d mongo
+  SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" exec -T mongo sh -c '
+    while ! '$MONGOSH' --eval "db.version()" > /dev/null; do
       echo "Waiting for Mongo..."
       sleep 1
     done
-    mongo --eval "rs.initiate({ _id: \"overleaf\", members: [ { _id: 0, host: \"mongo:27017\" } ] })" > /dev/null'
+    '$MONGOSH' --eval "db.isMaster().primary || rs.initiate({ _id: \"overleaf\", members: [ { _id: 0, host: \"mongo:27017\" } ] })" > /dev/null'
 }
 
 function pull_sandboxed_compiles() {
@@ -76,6 +76,7 @@ function __main__() {
   fi
 
   read_image_version
+  read_mongo_version
   check_config
   read_config
 
@@ -87,7 +88,7 @@ function __main__() {
     pull_sandboxed_compiles
   fi
 
-  exec "$TOOLKIT_ROOT/bin/docker-compose" up "$@"
+  exec env SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" up "$@"
 }
 
 __main__ "$@"

--- a/lib/docker-compose.mongo.yml
+++ b/lib/docker-compose.mongo.yml
@@ -4,7 +4,7 @@ services:
 
     mongo:
         restart: always
-        image: "${MONGO_IMAGE}"
+        image: "${MONGO_DOCKER_IMAGE}"
         command: "${MONGO_ARGS}"
         container_name: mongo
         volumes:
@@ -12,7 +12,7 @@ services:
         expose:
             - 27017
         healthcheck:
-            test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
+            test: echo 'db.stats().ok' | ${MONGOSH} localhost:27017/test --quiet
             interval: 10s
             timeout: 10s
             retries: 5

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -19,6 +19,54 @@ function read_image_version() {
   IMAGE_VERSION_PATCH=${BASH_REMATCH[3]}
 }
 
+function read_mongo_version() {
+  local mongo_image=$(read_configuration "MONGO_IMAGE")
+  local mongo_version=$(read_configuration "MONGO_VERSION")
+  if [ -z "${mongo_version}" ]; then
+    if [[ "$mongo_image" =~ ^mongo:([0-9]+)\.(.*)$ ]]; then
+      # when running a chain of commands (example: bin/up -> bin/docker-compose) we're passing
+      # SKIP_WARNINGS=true to prevent the warning message to be printed several times
+      if [[ -z ${SKIP_WARNINGS:-} ]]; then
+        echo "-------------------  WARNING  ----------------------"
+        echo "  Deprecation warning: the mongo image is now split between MONGO_IMAGE"
+        echo "  and MONGO_VERSION configurations. Please update your config/overleaf.rc as"
+        echo "  your current configuration may stop working in future versions of the toolkit."
+        echo "  Example: MONGO_IMAGE=mongo"
+        echo "           MONGO_VERSION=6.0"
+      fi
+      MONGO_VERSION_MAJOR=${BASH_REMATCH[1]}
+      MONGO_DOCKER_IMAGE="$mongo_image"
+    else
+      echo "---------------------  ERROR  -----------------------"
+      echo "  The mongo image is now split between MONGO_IMAGE and MONGO_VERSION configurations."
+      echo "  Please update your config/overleaf.rc."
+      echo ""
+      echo "  MONGO_VERSION must start with the actual major version of mongo, followed by a dot."
+      echo "  Example: MONGO_IMAGE=my.dockerhub.com/mongo"
+      echo "           MONGO_VERSION=6.0-custom"
+      exit 1
+    fi
+  else
+    if [[ ! "$mongo_version" =~ ^([0-9]+)\.(.+)$ ]]; then
+      echo "---------------------  ERROR  -----------------------"
+      echo "  Invalid MONGO_VERSION: $mongo_version"
+      echo ""
+      echo "  MONGO_VERSION must start with the actual major version of mongo, followed by a dot."
+      echo "  Example: MONGO_IMAGE=my.dockerhub.com/custom-mongo"
+      echo "           MONGO_VERSION=6.0.hotfix-1"
+      exit 1
+    fi
+    MONGO_VERSION_MAJOR=${BASH_REMATCH[1]}
+    MONGO_DOCKER_IMAGE="$mongo_image:$mongo_version"
+  fi
+
+  if [[ "$MONGO_VERSION_MAJOR" -lt 6 ]]; then
+    MONGOSH="mongo"
+  else
+    MONGOSH="mongosh"
+  fi
+}
+
 function check_retracted_version() {
   if [[ "${OVERLEAF_SKIP_RETRACTION_CHECK:-null}" == "$IMAGE_VERSION" ]]; then
     return
@@ -129,5 +177,11 @@ function check_sharelatex_env_vars() {
 function read_variable() {
   local name=$1
   grep -E "^$name=" "$TOOLKIT_ROOT/config/variables.env" \
+  | sed -r "s/^$name=([\"']*)(.+)\1*\$/\2/"
+}
+
+function read_configuration() {
+  local name=$1
+  grep -E "^$name=" "$TOOLKIT_ROOT/config/overleaf.rc" \
   | sed -r "s/^$name=([\"']*)(.+)\1*\$/\2/"
 }

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -33,6 +33,7 @@ function read_mongo_version() {
         echo "  your current configuration may stop working in future versions of the toolkit."
         echo "  Example: MONGO_IMAGE=mongo"
         echo "           MONGO_VERSION=6.0"
+        echo "-------------------  WARNING  ----------------------"
       fi
       MONGO_VERSION_MAJOR=${BASH_REMATCH[1]}
       MONGO_DOCKER_IMAGE="$mongo_image"
@@ -42,8 +43,9 @@ function read_mongo_version() {
       echo "  Please update your config/overleaf.rc."
       echo ""
       echo "  MONGO_VERSION must start with the actual major version of mongo, followed by a dot."
-      echo "  Example: MONGO_IMAGE=my.dockerhub.com/mongo"
+      echo "  Example: MONGO_IMAGE=my.dockerhub.com/custom-mongo"
       echo "           MONGO_VERSION=6.0-custom"
+      echo "---------------------  ERROR  -----------------------"
       exit 1
     fi
   else
@@ -53,7 +55,8 @@ function read_mongo_version() {
       echo ""
       echo "  MONGO_VERSION must start with the actual major version of mongo, followed by a dot."
       echo "  Example: MONGO_IMAGE=my.dockerhub.com/custom-mongo"
-      echo "           MONGO_VERSION=6.0.hotfix-1"
+      echo "           MONGO_VERSION=6.0-custom"
+      echo "---------------------  ERROR  -----------------------"
       exit 1
     fi
     MONGO_VERSION_MAJOR=${BASH_REMATCH[1]}


### PR DESCRIPTION
## Description


Adds support for Mongo 6.0 in preparation for the next minor release. The main changes are:

- `mongo` shell has been replaced by `mongosh`. The toolkit now reads Mongo major version from `overleaf.rc` and sets a `MONGOSH` variable that is used in different places to invoke the Mongo shell.
- Replica set initialisation with `rs.initiate()` fails in Mongo 6.0 when the replica set is already initialised. It's now checking `db.isMaster().primary` beforehand, which should return an empty string if the replicaSet is not initialised.

Upgrade instructions have been updated: https://github.com/overleaf/overleaf/wiki/Updating-Mongo-version/_compare/4e81c4348e2f8a30e2676af13ca7271493f53e75...acc881bbfc8f257d8d1b016e0ecbdd6cbc12b0ce

**Test**

With `MONGO_IMAGE=mongo:5.0` in `overleaf.rc`:

```
# Image inspection
"Image": "mongo:5.0",
 "Healthcheck": {
            "Test": [
                "CMD-SHELL",
                "echo 'db.stats().ok' | mongo localhost:27017/test --quiet"
            ],
            "Interval": 10000000000,
            "Timeout": 10000000000,
            "Retries": 5
},
```

```
$ bin/mongo
MongoDB shell version v5.0.18
connecting to: mongodb://127.0.0.1:27017/sharelatex?compressors=disabled&gssapiServiceName=mongodb
```

Updated `MONGO_IMAGE=mongo:6.0` in `overleaf.rc` (previously set feature compatibility to `5.0`):

```
# Image inspection
 "Image": "mongo:6.0",
 "Healthcheck": {
            "Test": [
                "CMD-SHELL",
                "echo 'db.stats().ok' | mongosh localhost:27017/test --quiet"
            ],
            "Interval": 10000000000,
            "Timeout": 10000000000,
            "Retries": 5
        },
```

```
$ bin/mongo
Current Mongosh Log ID: 667032abd41272b4ef8db5fa
Connecting to:          mongodb://127.0.0.1:27017/sharelatex?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.2.6
Using MongoDB:          6.0.15
Using Mongosh:          2.2.6
```


In both versions: tested login, project creation and compiles.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
