### PR TITLE
Added '--appendonly yes' configuration to redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2024-07-27
+### Added
+- Added "--appendonly yes" configuration to redis.
+
+  redis persistence documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/
+
 ## 2024-07-16
 ### Added
 - Added support for Mongo 6.0.

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -109,6 +109,17 @@ function set_redis_vars() {
   DOCKER_COMPOSE_FLAGS+=(-f "$TOOLKIT_ROOT/lib/docker-compose.redis.yml")
   export REDIS_IMAGE
   export REDIS_DATA_PATH
+
+  if [[ -z "${REDIS_AOF_PERSISTENCE:-}" ]]; then
+    echo "WARNING: the value of REDIS_AOF_PERSISTENCE is not set in config/overleaf.rc"
+    echo "See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#server-pro-510"
+    REDIS_COMMAND="redis-server"
+  elif [[ $REDIS_AOF_PERSISTENCE == "true" ]]; then
+    REDIS_COMMAND="redis-server --appendonly yes"
+  else
+    REDIS_COMMAND="redis-server"
+  fi
+  export REDIS_COMMAND
 }
 
 # Set environment variables for docker-compose.mongo.yml

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -112,7 +112,7 @@ function set_redis_vars() {
 
   if [[ -z "${REDIS_AOF_PERSISTENCE:-}" ]]; then
     echo "WARNING: the value of REDIS_AOF_PERSISTENCE is not set in config/overleaf.rc"
-    echo "See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#server-pro-510"
+    echo "See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x/_edit#redis-aof-persistence-enabled-by-default"
     REDIS_COMMAND="redis-server"
   elif [[ $REDIS_AOF_PERSISTENCE == "true" ]]; then
     REDIS_COMMAND="redis-server --appendonly yes"

--- a/bin/doctor
+++ b/bin/doctor
@@ -256,6 +256,9 @@ function check_config_files() {
         if [[ "${REDIS_IMAGE:-null}" != "null" ]]; then
           print_point 2 "REDIS_IMAGE: $REDIS_IMAGE"
         fi
+        if [[ "${REDIS_AOF_PERSISTENCE:-null}" != "null" ]]; then
+          print_point 2 "REDIS_AOF_PERSISTENCE: $REDIS_AOF_PERSISTENCE"
+        fi
         if [[ "${REDIS_DATA_PATH:-null}" != "null" ]]; then
           print_point 2 "REDIS_DATA_PATH: $REDIS_DATA_PATH"
         fi

--- a/lib/config-seed/overleaf.rc
+++ b/lib/config-seed/overleaf.rc
@@ -23,6 +23,7 @@ MONGO_IMAGE=mongo:5.0
 REDIS_ENABLED=true
 REDIS_DATA_PATH=data/redis
 REDIS_IMAGE=redis:6.2
+REDIS_AOF_PERSISTENCE=true
 
 # Git-bridge configuration (Server Pro only)
 GIT_BRIDGE_ENABLED=false

--- a/lib/docker-compose.redis.yml
+++ b/lib/docker-compose.redis.yml
@@ -8,6 +8,7 @@ services:
         volumes:
             - "${REDIS_DATA_PATH}:/data"
         container_name: redis
+        command: ${REDIS_COMMAND}
         expose:
             - 6379
 


### PR DESCRIPTION
## Description
Turns on redis `appendonly` on config-seed for new installs, and introduces an `REDIS_AOF_PERSISTENCE` variable to enable it on existing installs, printing a warning when it's not defined.

https://redis.io/docs/latest/operate/oss_and_stack/management/persistence

AOF Persistence writes all redis updates to a journal, allowing better recovery and mitigating potential data loss after shutdown

`--appendonly yes` is set via `docker-compose` `command` option since overriding `CMD` is the recommendation of the official docker image https://hub.docker.com/_/redis. 

### Manual test

Tested login, load and compiled projects.

When `REDIS_AOF_PERSISTENCE` is not defined:

```sh
$ bin/up -d redis
Initiating Mongo replica set...
WARNING: the value of REDIS_AOF_PERSISTENCE is not set in config/overleaf.rc
See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#server-pro-510
[+] Running 1/2
...

$docker inspect redis | jq '.[0].Args'
[
  "redis-server"
]
```

When `REDIS_AOF_PERSISTENCE=true`:

```sh
$ bin/up -d redis
Initiating Mongo replica set...
[+] Running 1/2
...

$docker inspect redis | jq '.[0].Args'
[
  "redis-server",
  "--appendonly",
  "yes"
]
```

When `REDIS_AOF_PERSISTENCE=false`:

```sh
$ bin/up -d redis
Initiating Mongo replica set...
[+] Running 1/2
...

$docker inspect redis | jq '.[0].Args'
[
  "redis-server"
]
```

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
