### PR TITLE
bin/doctor: Add deprecation warning for Docker older than v23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   Support for docker-compose v1 in the Overleaf Toolkit will be dropped with the release of Server Pro 5.2.
   We recommend upgrading to Docker Compose v2 before then.
 
+- Added warning for usage of End Of Life Docker versions before v23
+
 ## 2024-06-20
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.0.6`.

--- a/bin/doctor
+++ b/bin/doctor
@@ -141,6 +141,18 @@ function check_docker_daemon() {
   if docker ps &>/dev/null;  then
     print_point 1 "status: up"
 
+    local docker_server_version=$(docker version -f '{{.Server.Version}}')
+    print_point 1 "server version: $docker_server_version"
+    if [[ "$docker_server_version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+      local major="${BASH_REMATCH[1]}"
+      local minor="${BASH_REMATCH[2]}"
+      if [[ "$major" -lt 23 ]]; then
+        add_warning "Docker v$major.$minor has reached its End Of Life. We recommend upgrading to a supported version."
+      fi
+    else
+      add_warning "Docker server version unknown ($docker_server_version)"
+    fi
+
     if docker info | grep -q -e '/var/snap/docker/common/var-lib-docker'; then
       add_warning "Installing Docker via snap is not supported. The sandboxed compiles feature may not be available. Please follow the steps for installing Docker CE on https://docs.docker.com/engine/install/."
     fi


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Part of https://github.com/overleaf/internal/issues/17607

Codify the support policy for Docker as defined in https://github.com/overleaf/overleaf/wiki/Dependencies

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Part of https://github.com/overleaf/internal/issues/17607

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
