### PR TITLE
Fix URL for Redis AOF docs

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -112,7 +112,7 @@ function set_redis_vars() {
 
   if [[ -z "${REDIS_AOF_PERSISTENCE:-}" ]]; then
     echo "WARNING: the value of REDIS_AOF_PERSISTENCE is not set in config/overleaf.rc"
-    echo "See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x/_edit#redis-aof-persistence-enabled-by-default"
+    echo "See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#redis-aof-persistence-enabled-by-default"
     REDIS_COMMAND="redis-server"
   elif [[ $REDIS_AOF_PERSISTENCE == "true" ]]; then
     REDIS_COMMAND="redis-server --appendonly yes"


### PR DESCRIPTION
## Description

Fixes URL that was pointing to the edit page.



## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
