### PR TITLE
Sandboxed Compiles is available for Server Pro only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-07-29
+### Fixed
+- Sandboxed Compiles is available for Server Pro only
+
 ## 2024-07-17
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.1.0`.

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -28,7 +28,7 @@ function build_environment() {
   if [[ $MONGO_ENABLED == "true" ]]; then
     set_mongo_vars
   fi
-  if [[ $SIBLING_CONTAINERS_ENABLED == "true" ]]; then
+  if [[ $SERVER_PRO == "true" && "$SIBLING_CONTAINERS_ENABLED" == "true" ]]; then
     set_sibling_containers_vars
   fi
   if [[ $NGINX_ENABLED == "true" ]]; then

--- a/bin/up
+++ b/bin/up
@@ -84,7 +84,7 @@ function __main__() {
     initiate_mongo_replica_set
   fi
 
-  if [[ "$SIBLING_CONTAINERS_ENABLED" == "true" ]]; then
+  if [[ $SERVER_PRO == "true" && "$SIBLING_CONTAINERS_ENABLED" == "true" ]]; then
     pull_sandboxed_compiles
   fi
 


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Closes https://github.com/overleaf/toolkit/issues/272

Only action on  `SIBLING_CONTAINERS_ENABLED=true` when Server Pro is enabled.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Closes https://github.com/overleaf/toolkit/issues/272

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
