### PR TITLE
Fix unquoting of variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-08-20
+### Fixed
+- Fix unquoting of variables (e.g. `ALL_TEX_LIVE_DOCKER_IMAGES`)
+
 ## 2024-08-13
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.1.1`.

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -180,11 +180,11 @@ function check_sharelatex_env_vars() {
 function read_variable() {
   local name=$1
   grep -E "^$name=" "$TOOLKIT_ROOT/config/variables.env" \
-  | sed -r "s/^$name=([\"']*)(.+)\1*\$/\2/"
+  | sed -r "s/^$name=([\"']?)(.+)\1\$/\2/"
 }
 
 function read_configuration() {
   local name=$1
   grep -E "^$name=" "$TOOLKIT_ROOT/config/overleaf.rc" \
-  | sed -r "s/^$name=([\"']*)(.+)\1*\$/\2/"
+  | sed -r "s/^$name=([\"']?)(.+)\1\$/\2/"
 }


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

- Fix trimming of matching quote (no star after \1 reference)
- Only trim a single quote (turn any-match into optional match)

Tested with `bin/up --dry-run`
- `ALL_TEX_LIVE_DOCKER_IMAGES=quay.io/sharelatex/texlive-full:2022.1,quay.io/sharelatex/texlive-full:2023.1` -> works
- `ALL_TEX_LIVE_DOCKER_IMAGES="quay.io/sharelatex/texlive-full:2022.1,quay.io/sharelatex/texlive-full:2023.1"` -> works
- `ALL_TEX_LIVE_DOCKER_IMAGES='quay.io/sharelatex/texlive-full:2022.1,quay.io/sharelatex/texlive-full:2023.1'` -> works
- `ALL_TEX_LIVE_DOCKER_IMAGES="'quay.io/sharelatex/texlive-full:2022.1,quay.io/sharelatex/texlive-full:2023.1'"` -> fails as expected, only one quote is removed

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

As reported by customer

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
