### PR TITLE
Update changelog entry for automatic pulling of TeXLive images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 ### Added
 - Pull TeX Live images from `bin/up`
 
+  You can disable the automatic pulling using `SIBLING_CONTAINERS_PULL=false` in your `config/overleaf.rc` file.
+
 ## 2024-05-24
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.0.4`.


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Part of https://github.com/overleaf/internal/issues/17497
Follow up for #258 

`SIBLING_CONTAINERS_PULL=false` is documented in [the toolkit docs](https://github.com/overleaf/toolkit/blob/master/doc/sandboxed-compiles.md#enabling-sibling-containers), and as of today in Server Pro release notes as well, but it does not hurt to give it even more exposure :wink: 

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Part of https://github.com/overleaf/internal/issues/17497
Follow up for #258 

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
