### PR TITLE
Loud warning for SIBLING_CONTAINERS_ENABLED=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2024-08-27
 ### Added
 - Add loud warning to `bin/doctor` when not using Sandboxed Compiles/`SIBLING_CONTAINERS_ENABLED=true`
-- Refuse to start Community Edition with `SIBLING_CONTAINERS_ENABLED=true`
+- Add loud warning for using Community Edition with `SIBLING_CONTAINERS_ENABLED=true`
 
 ## 2024-08-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## 2024-09-03
-### Added
-- Add a new config option `OVERLEAF_LOG_PATH` for making [application logs](https://github.com/overleaf/overleaf/wiki/Log-files) available on the Docker host.
-
-## 2024-08-27
+## 2024-09-11
 ### Added
 - Add loud warning to `bin/doctor` when not using Sandboxed Compiles/`SIBLING_CONTAINERS_ENABLED=true`
 - Add loud warning for using Community Edition with `SIBLING_CONTAINERS_ENABLED=true`
+
+## 2024-09-03
+### Added
+- Add a new config option `OVERLEAF_LOG_PATH` for making [application logs](https://github.com/overleaf/overleaf/wiki/Log-files) available on the Docker host.
 
 ## 2024-08-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2024-08-27
 ### Added
+- Add loud warning to `bin/doctor` when not using Sandboxed Compiles/`SIBLING_CONTAINERS_ENABLED=true`
+- Refuse to start Community Edition with `SIBLING_CONTAINERS_ENABLED=true`
+
+## 2024-08-27
+### Added
 - Surface `MONGO_VERSION` from `bin/doctor`
 
 ## 2024-08-20

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -28,8 +28,17 @@ function build_environment() {
   if [[ $MONGO_ENABLED == "true" ]]; then
     set_mongo_vars
   fi
-  if [[ $SERVER_PRO == "true" && "$SIBLING_CONTAINERS_ENABLED" == "true" ]]; then
-    set_sibling_containers_vars
+  if [[ "$SIBLING_CONTAINERS_ENABLED" == "true" ]]; then
+    if [[ $SERVER_PRO == "true" ]]; then
+      set_sibling_containers_vars
+    else
+      echo "ERROR: SIBLING_CONTAINERS_ENABLED=true is not supported in Overleaf Community Edition." >&2
+      echo "  Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required." >&2
+      echo "  When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles." >&2
+      echo "  Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features." >&2
+      echo "  Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to continue using insecure in-container compiles." >&2
+      exit 1
+    fi
   fi
   if [[ $NGINX_ENABLED == "true" ]]; then
     set_nginx_vars
@@ -112,7 +121,7 @@ function set_redis_vars() {
 
   if [[ -z "${REDIS_AOF_PERSISTENCE:-}" ]]; then
     echo "WARNING: the value of REDIS_AOF_PERSISTENCE is not set in config/overleaf.rc"
-    echo "See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#redis-aof-persistence-enabled-by-default"
+    echo "  See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#redis-aof-persistence-enabled-by-default"
     REDIS_COMMAND="redis-server"
   elif [[ $REDIS_AOF_PERSISTENCE == "true" ]]; then
     REDIS_COMMAND="redis-server --appendonly yes"

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -36,7 +36,7 @@ function build_environment() {
       echo "  Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required." >&2
       echo "  When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles." >&2
       echo "  Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features." >&2
-      echo "  Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to continue using insecure in-container compiles." >&2
+      echo "  Falling back using insecure in-container compiles. Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to silence this warning." >&2
     fi
   fi
   if [[ $NGINX_ENABLED == "true" ]]; then

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -32,11 +32,13 @@ function build_environment() {
     if [[ $SERVER_PRO == "true" ]]; then
       set_sibling_containers_vars
     else
-      echo "WARNING: SIBLING_CONTAINERS_ENABLED=true is not supported in Overleaf Community Edition." >&2
-      echo "  Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required." >&2
-      echo "  When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles." >&2
-      echo "  Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features." >&2
-      echo "  Falling back using insecure in-container compiles. Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to silence this warning." >&2
+      if [[ ${SKIP_WARNINGS:-null} != "true" ]]; then
+        echo "WARNING: SIBLING_CONTAINERS_ENABLED=true is not supported in Overleaf Community Edition." >&2
+        echo "  Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required." >&2
+        echo "  When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles." >&2
+        echo "  Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features." >&2
+        echo "  Falling back using insecure in-container compiles. Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to silence this warning." >&2
+      fi
     fi
   fi
   if [[ $NGINX_ENABLED == "true" ]]; then
@@ -80,7 +82,9 @@ function set_base_vars() {
 
   if [[ ${OVERLEAF_LISTEN_IP:-null} == "null" ]];
   then
-    echo "WARNING: the value of OVERLEAF_LISTEN_IP is not set in config/overleaf.rc. This value must be set to the public IP address for direct container access. Defaulting to 0.0.0.0" >&2
+    if [[ ${SKIP_WARNINGS:-null} != "true" ]]; then
+      echo "WARNING: the value of OVERLEAF_LISTEN_IP is not set in config/overleaf.rc. This value must be set to the public IP address for direct container access. Defaulting to 0.0.0.0" >&2
+    fi
     OVERLEAF_LISTEN_IP="0.0.0.0"
   fi
   export OVERLEAF_LISTEN_IP
@@ -119,8 +123,10 @@ function set_redis_vars() {
   export REDIS_DATA_PATH
 
   if [[ -z "${REDIS_AOF_PERSISTENCE:-}" ]]; then
-    echo "WARNING: the value of REDIS_AOF_PERSISTENCE is not set in config/overleaf.rc"
-    echo "  See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#redis-aof-persistence-enabled-by-default"
+    if [[ ${SKIP_WARNINGS:-null} != "true" ]]; then
+      echo "WARNING: the value of REDIS_AOF_PERSISTENCE is not set in config/overleaf.rc"
+      echo "  See https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#redis-aof-persistence-enabled-by-default"
+    fi
     REDIS_COMMAND="redis-server"
   elif [[ $REDIS_AOF_PERSISTENCE == "true" ]]; then
     REDIS_COMMAND="redis-server --appendonly yes"
@@ -219,7 +225,9 @@ function docker_compose() {
     exec docker compose "${flags[@]}"
   elif command -v docker-compose >/dev/null; then
     # Fall back to docker-compose v1
-    echo "WARNING: docker-compose v1 has reached its End Of Life in July 2023 (https://docs.docker.com/compose/migrate/). Support for docker-compose v1 in the Overleaf Toolkit will be dropped with the release of Server Pro 5.2. We recommend upgrading to Docker Compose v2 before then." >&2
+    if [[ ${SKIP_WARNINGS:-null} != "true" ]]; then
+      echo "WARNING: docker-compose v1 has reached its End Of Life in July 2023 (https://docs.docker.com/compose/migrate/). Support for docker-compose v1 in the Overleaf Toolkit will be dropped with the release of Server Pro 5.2. We recommend upgrading to Docker Compose v2 before then." >&2
+    fi
     exec docker-compose "${flags[@]}"
   else
     echo "ERROR: Could not find Docker Compose." >&2

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -32,12 +32,11 @@ function build_environment() {
     if [[ $SERVER_PRO == "true" ]]; then
       set_sibling_containers_vars
     else
-      echo "ERROR: SIBLING_CONTAINERS_ENABLED=true is not supported in Overleaf Community Edition." >&2
+      echo "WARNING: SIBLING_CONTAINERS_ENABLED=true is not supported in Overleaf Community Edition." >&2
       echo "  Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required." >&2
       echo "  When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles." >&2
       echo "  Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features." >&2
       echo "  Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to continue using insecure in-container compiles." >&2
-      exit 1
     fi
   fi
   if [[ $NGINX_ENABLED == "true" ]]; then

--- a/bin/doctor
+++ b/bin/doctor
@@ -212,6 +212,10 @@ function check_config_files() {
         fi
 
         print_point 2 "SERVER_PRO: $SERVER_PRO"
+        print_point 2 "SIBLING_CONTAINERS_ENABLED: $SIBLING_CONTAINERS_ENABLED"
+        if [[ "${SIBLING_CONTAINERS_ENABLED:-null}" != "true" ]]; then
+          add_warning "Detected SIBLING_CONTAINERS_ENABLED=false. When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles. Only use this mode in environments where all users are trusted and no isolation of users is required."
+        fi
         if [[ "${SERVER_PRO:-null}" == "true" ]]; then
           local logged_in
           logged_in="$(grep -q quay.io ~/.docker/config.json && echo 'true' || echo 'false')"
@@ -226,7 +230,8 @@ function check_config_files() {
             )
             add_warning "${warning_message[@]}"
           fi
-          print_point 2 "SIBLING_CONTAINERS_ENABLED: $SIBLING_CONTAINERS_ENABLED"
+        elif [[ "${SIBLING_CONTAINERS_ENABLED:-null}" == "true" ]]; then
+          add_warning "Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required. Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features. Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to continue using insecure in-container compiles."
         fi
         if [[ "${OVERLEAF_LISTEN_IP:-null}" != "null" ]]; then
           print_point 2 "OVERLEAF_LISTEN_IP: ${OVERLEAF_LISTEN_IP}"

--- a/bin/up
+++ b/bin/up
@@ -37,8 +37,8 @@ function check_config() {
 
 function initiate_mongo_replica_set() {
   echo "Initiating Mongo replica set..."
-  SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" up -d mongo
-  SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" exec -T mongo sh -c '
+  env SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" up -d mongo
+  env SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" exec -T mongo sh -c '
     while ! '$MONGOSH' --eval "db.version()" > /dev/null; do
       echo "Waiting for Mongo..."
       sleep 1
@@ -76,7 +76,7 @@ function __main__() {
   fi
 
   read_image_version
-  read_mongo_version
+  SKIP_WARNINGS=true read_mongo_version
   check_config
   read_config
 
@@ -88,7 +88,7 @@ function __main__() {
     pull_sandboxed_compiles
   fi
 
-  exec env SKIP_WARNINGS=true "$TOOLKIT_ROOT/bin/docker-compose" up "$@"
+  exec "$TOOLKIT_ROOT/bin/docker-compose" up "$@"
 }
 
 __main__ "$@"

--- a/doc/sandboxed-compiles.md
+++ b/doc/sandboxed-compiles.md
@@ -1,6 +1,12 @@
 # Sandboxed Compiles
 
-In Server Pro, it is possible to have each LaTeX project be compiled in a separate docker container, achieving sandbox isolation between projects. 
+In Server Pro, it is possible to have each LaTeX project be compiled in a separate docker container, achieving sandbox isolation between projects.
+
+This feature is also known as "Sibling containers" as LaTeX compiles are running in a sibling container next to the Server Pro docker container.
+
+When not using Sandboxed Compiles, users have full read and write access to the `sharelatex` container resources (filesystem, network, environment variables) when running LaTeX compiles.
+
+Note: Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required.
 
 ## How It Works
 

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -26,7 +26,7 @@ function read_mongo_version() {
     if [[ "$mongo_image" =~ ^mongo:([0-9]+)\.(.*)$ ]]; then
       # when running a chain of commands (example: bin/up -> bin/docker-compose) we're passing
       # SKIP_WARNINGS=true to prevent the warning message to be printed several times
-      if [[ -z ${SKIP_WARNINGS:-} ]]; then
+      if [[ ${SKIP_WARNINGS:-null} != "true" ]]; then
         echo "-------------------  WARNING  ----------------------"
         echo "  Deprecation warning: the mongo image is now split between MONGO_IMAGE"
         echo "  and MONGO_VERSION configurations. Please update your config/overleaf.rc as"


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
Part of https://github.com/overleaf/internal/issues/19878
Part of https://github.com/overleaf/internal/issues/19290

This PR is doubling on the new default for `SIBLING_CONTAINERS_ENABLED`:
- Add loud warning for using `SIBLING_CONTAINERS_ENABLED=false`
- Refuses to start with `SIBLING_CONTAINERS_ENABLED=true` outside Server Pro

We could also add a warning to `bin/up` / `bin/start` / `bin/upgrade` for using `SIBLING_CONTAINERS_ENABLED=false` in Server Pro.

The later point has the affect that `bin/init` followed by `bin/up` does no longer work out of the box. I'm on the fence of moving forward with this:
Pro:
- Admins will be aware of the implication for running without Sandboxed Compiles
- We raise awareness for Server Pro offering

Contra:
- Ease of use for simple CE environments
- Ease of setting up demo instances

cc @overleaf/security 

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Part of https://github.com/overleaf/internal/issues/19878
Part of https://github.com/overleaf/internal/issues/19290

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)


### Screenshots

#### Pro + enabled:

No new warnings

#### Pro + disabled:
```
$ bin/doctor
...
====== Warnings ======
! Detected SIBLING_CONTAINERS_ENABLED=false. When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles. Only use this mode in environments where all users are trusted and no isolation of users is required.
====== End ======

$  bin/up
...
// no new warnings
 ✔ Container sharelatex  Recreated ...
```
#### CE+enabled:
```
$ bin/doctor
...
====== Warnings ======
! Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required. Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features. Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to continue using insecure in-container compiles.
====== End ======

$  bin/up
...
ERROR: SIBLING_CONTAINERS_ENABLED=true is not supported in Overleaf Community Edition.
  Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required.
  When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles.
  Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features.
  Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to continue using insecure in-container compiles.
```

#### CE+disabled
```
$ bin/doctor
...
====== Warnings ======
! Detected SIBLING_CONTAINERS_ENABLED=false. When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles. Only use this mode in environments where all users are trusted and no isolation of users is required.
====== End ======

$  bin/up
...
// no new warnings
 ✔ Container sharelatex  Recreated ...
```