### PR TITLE
Add section on selecting Server Pro to Quick Start Guide

### DIFF
--- a/doc/quick-start-guide.md
+++ b/doc/quick-start-guide.md
@@ -74,6 +74,15 @@ These are the three configuration files you will interact with:
 - `variables.env` : environment variables loaded into the docker container
 - `version` : the version of the docker images to use
 
+## Selecting Overleaf Community Edition or Server Pro
+
+By default, the Overleaf Toolkit uses the free Overleaf Community Edition.
+
+Overleaf Server Pro is a commercial version of Overleaf, with extra features and commercial support.
+See https://www.overleaf.com/for/enterprises/features for more details about Server Pro and how to
+buy a license.
+
+In case you are a Server Pro customer, or want to set up a Server Pro trial instance, please follow the [docs on switching to Server Pro](getting-server-pro.md) before continuing with the next step.
 
 ## Starting Up
 


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Add section on selecting Server Pro to Quick Start Guide to avoid downloading CE/disabling sandboxed compiles before switching to Server Pro.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Recent support case

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
