### PR TITLE
Print warning when running "bin/up" without detach mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-09-24
+### Added
+- Print warning when running `bin/up` without detach mode
+
 ## 2024-09-11
 ### Added
 - Add loud warning to `bin/doctor` when not using Sandboxed Compiles/`SIBLING_CONTAINERS_ENABLED=true`

--- a/bin/up
+++ b/bin/up
@@ -69,6 +69,24 @@ function pull_sandboxed_compiles() {
   done
 }
 
+function notify_about_not_using_detach_mode() {
+  local detached=false
+  for arg in "$@"; do
+    case "$arg" in
+        -d|--detach) detached=true;;
+    esac
+  done
+  if [[ "$detached" == false ]]; then
+    echo
+    echo '---'
+    echo
+    echo '  NOTICE: You are running "bin/up" without the detach mode ("-d" or "--detach" option). Behind the scenes, we will invoke "docker compose up", which will tail the container logs indefinitely until you issue a keyboard interrupt (CTRL+C).'
+    echo
+    echo '---'
+    echo
+  fi
+}
+
 function __main__() {
   if [[ "${1:-null}" == "help" ]] || [[ "${1:-null}" == "--help" ]]; then
     usage
@@ -88,6 +106,7 @@ function __main__() {
     pull_sandboxed_compiles
   fi
 
+  notify_about_not_using_detach_mode "$@"
   exec "$TOOLKIT_ROOT/bin/docker-compose" up "$@"
 }
 


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

There have been numerous cases where CE users/Server Pro customers expect `bin/up` to exit eventually once Server Pro is up. This is not the case, they need to turn on the docker compose detach mode for `bin/up` to exit. This PR is adding a warning message to hint on detach mode.

```
$ bin/up
...

---

  NOTICE: You are running "bin/up" without the detach mode ("-d" or "--detach" option). Behind the scenes, we will invoke "docker compose up", which will tail the container logs indefinitely until you issue a keyboard interrupt (CTRL+C).

---

...

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

See most recent upgrade support case.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
