### PR TITLE
update regex to support BSD sed (for macOS devs) and GNU sed

### DIFF
--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -180,11 +180,11 @@ function check_sharelatex_env_vars() {
 function read_variable() {
   local name=$1
   grep -E "^$name=" "$TOOLKIT_ROOT/config/variables.env" \
-  | sed -r "s/^$name=([\"']?)(.+)\1\$/\2/"
+  | sed -r "s/^$name=([\"']?)([^\"']+)[\"']?$/\2/"
 }
 
 function read_configuration() {
   local name=$1
   grep -E "^$name=" "$TOOLKIT_ROOT/config/overleaf.rc" \
-  | sed -r "s/^$name=([\"']?)(.+)\1\$/\2/"
+  | sed -r "s/^$name=([\"']?)([^\"']+)[\"']?$/\2/"
 }


### PR DESCRIPTION
## Description
The sed parsing present in `lib/shared_function.sh` does not work correctly on macOS because macOS by default uses BSD sed instead of GNU sed. Updated the regex so it works correctly for both BSD and GNU sed.

One possible alternative to this PR could be to add a note in the guide for macOS users so they are aware of the issue and can workaround it by installing GNU sed and using that in the script, however I think this PR makes it easier and reduces the onus on new developers.

## Related issues / Pull Requests
Fixes #287 

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
