### PR TITLE
Append version to GIT_BRIDGE_IMAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2024-10-23
+### Changed
+- If set, the `overleaf.rc` entry `GIT_BRIDGE_IMAGE` must be specified without the version now.
+
+  Example:
+  ```diff
+  -GIT_BRIDGE_IMAGE=my.registry.com/overleaf/git-bridge:5.1.1
+  +GIT_BRIDGE_IMAGE=my.registry.com/overleaf/git-bridge
+  ```
+
 ## 2024-09-24
 ### Added
 - Print warning when running `bin/up` without detach mode

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -206,7 +206,7 @@ function set_nginx_vars() {
 function set_git_bridge_vars() {
   local image_name
   if [[ -n ${GIT_BRIDGE_IMAGE:-} ]]; then
-    image_name="$GIT_BRIDGE_IMAGE"
+    image_name="$GIT_BRIDGE_IMAGE:$IMAGE_VERSION"
   else
     image_name="quay.io/sharelatex/git-bridge:$IMAGE_VERSION"
   fi


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

While working on docs I noticed that the `GIT_BRIDGE_IMAGE` does not follow the schema of `OVERLEAF_IMAGE_NAME`, which is excluding the tag/version, which in turn is sourced from `config/version`. This PR is adding this difference.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Upcoming docs PR.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
