### PR TITLE
Pull new images from bin/upgrade ahead of stopping containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-10-29
+### Added
+- Pull new images from `bin/upgrade` ahead of stopping containers
+
 ## 2024-10-24
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.2.1`.

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -76,15 +76,7 @@ function set_base_vars() {
     DOCKER_COMPOSE_FLAGS+=(-f "$TOOLKIT_ROOT/lib/docker-compose.vars.yml")
   fi
 
-  local image_name
-  if [[ -n ${OVERLEAF_IMAGE_NAME:-} ]]; then
-    image_name="$OVERLEAF_IMAGE_NAME"
-  elif [[ $SERVER_PRO == "true" ]]; then
-    image_name="quay.io/sharelatex/sharelatex-pro"
-  else
-    image_name="sharelatex/sharelatex"
-  fi
-  export IMAGE="$image_name:$IMAGE_VERSION"
+  set_server_pro_image_name "$IMAGE_VERSION"
 
   if [[ ${OVERLEAF_LISTEN_IP:-null} == "null" ]];
   then
@@ -94,11 +86,6 @@ function set_base_vars() {
     OVERLEAF_LISTEN_IP="0.0.0.0"
   fi
   export OVERLEAF_LISTEN_IP
-
-  if [[ $SERVER_PRO != "true" || $IMAGE_VERSION_MAJOR -lt 4 ]]; then
-    # Force git bridge to be disabled if not ServerPro >= 4
-    GIT_BRIDGE_ENABLED=false
-  fi
 
   HAS_WEB_API=false
   if [[ $IMAGE_VERSION_MAJOR -gt 4 ]]; then
@@ -204,12 +191,7 @@ function set_nginx_vars() {
 
 # Set environment variables for docker-compose.git-bridge.yml
 function set_git_bridge_vars() {
-  local image_name
-  if [[ -n ${GIT_BRIDGE_IMAGE:-} ]]; then
-    image_name="$GIT_BRIDGE_IMAGE:$IMAGE_VERSION"
-  else
-    image_name="quay.io/sharelatex/git-bridge:$IMAGE_VERSION"
-  fi
+  set_git_bridge_image_name "$IMAGE_VERSION"
 
   GIT_BRIDGE_API_BASE_URL="http://sharelatex/api/v0/"
   if [[ $HAS_WEB_API == "true" ]]; then
@@ -218,7 +200,6 @@ function set_git_bridge_vars() {
 
   DOCKER_COMPOSE_FLAGS+=(-f "$TOOLKIT_ROOT/lib/docker-compose.git-bridge.yml")
   export GIT_BRIDGE_API_BASE_URL
-  export GIT_BRIDGE_IMAGE=${image_name}
   export GIT_BRIDGE_DATA_PATH
   export GIT_BRIDGE_LOG_LEVEL
 }

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -156,6 +156,14 @@ function handle_image_upgrade() {
     prompt "Are you following the recovery process?"
   fi
 
+  echo "Pulling new images"
+  set_server_pro_image_name "$SEED_IMAGE_VERSION"
+  docker pull "$IMAGE"
+  if [[ $GIT_BRIDGE_ENABLED == "true" ]]; then
+    set_git_bridge_image_name "$SEED_IMAGE_VERSION"
+    docker pull "$GIT_BRIDGE_IMAGE"
+  fi
+
   ## Offer to stop docker services
   local services_stopped="false"
   if services_up; then
@@ -260,6 +268,7 @@ function __main__() {
 
   read_seed_image_version
   read_image_version
+  read_config
   handle_rc_rebranding
   handle_image_upgrade
 

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -6,6 +6,11 @@ function read_config() {
   source "$TOOLKIT_ROOT/lib/default.rc"
   # shellcheck source=/dev/null
   source "$TOOLKIT_ROOT/config/overleaf.rc"
+
+  if [[ $SERVER_PRO != "true" || $IMAGE_VERSION_MAJOR -lt 4 ]]; then
+    # Force git bridge to be disabled if not ServerPro >= 4
+    GIT_BRIDGE_ENABLED=false
+  fi
 }
 
 function read_image_version() {
@@ -68,6 +73,30 @@ function read_mongo_version() {
   else
     MONGOSH="mongosh"
   fi
+}
+
+function set_server_pro_image_name() {
+  local version=$1
+  local image_name
+  if [[ -n ${OVERLEAF_IMAGE_NAME:-} ]]; then
+    image_name="$OVERLEAF_IMAGE_NAME"
+  elif [[ $SERVER_PRO == "true" ]]; then
+    image_name="quay.io/sharelatex/sharelatex-pro"
+  else
+    image_name="sharelatex/sharelatex"
+  fi
+  export IMAGE="$image_name:$version"
+}
+
+function set_git_bridge_image_name() {
+  local version=$1
+  local image_name
+  if [[ -n ${GIT_BRIDGE_IMAGE:-} ]]; then
+    image_name="$GIT_BRIDGE_IMAGE"
+  else
+    image_name="quay.io/sharelatex/git-bridge"
+  fi
+  export GIT_BRIDGE_IMAGE="$image_name:$version"
 }
 
 function check_retracted_version() {


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

While performing an upgrade, I noticed that we are taking down the site, then update config files and finally bring the site back up -- which likely requires pulling images first. We can avoid the downtime while pulling in fetching the images ahead of stopping containers.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Part of https://github.com/overleaf/internal/issues/19493

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
