### PR TITLE
Documentation getting to texlive-full

### DIFF
--- a/doc/quick-start-guide.md
+++ b/doc/quick-start-guide.md
@@ -185,6 +185,27 @@ First, we see some information about the host system (the machine that the toolk
 
 When you run into problems with your toolkit, you should first run the doctor script and check it's output. 
 
+## LaTeX environment
+
+To save bandwidth, the Overleaf image only comes with a minimal install of TeXLive. To upgrade to a complete TeXLive installation, run the installation script in the Overleaf container with the following command
+
+```sh
+$ docker exec sharelatex tlmgr install scheme-full
+```
+
+To make this changes persistent when docker restarts label current state (replace 0.0.0 with sharelatex version)
+
+```sh
+$ docker commit sharelatex sharelatex/sharelatex:0.0.0-with-texlive-full
+```
+
+thenn add `-with-texlive-full1` to the end of your version in config/version and run `bin/up -d` again.
+
+```sh
+$ cat config/version
+4.0.5-with-texlive-full
+```
+
 
 ## Getting Help
 


### PR DESCRIPTION
Improve quickstart to include texlive-full config

## Description

Currently it's hard to find instructions on getting texlive-full running with overleaf-toolkit. Following the manual stops at only a minimal installation.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
