### PR TITLE
`bin/upgrade`: skip downloading custom image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2024-11-18
+### Added
+- When a custom `GIT_BRIDGE_IMAGE` is set, `bin/upgrade` no longer tries to pull the new version, and prompts
+  the user to update and tag the custom image separately.
+
 ## 2024-10-29
 ### Added
 - Pull new images from `bin/upgrade` ahead of stopping containers

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -169,12 +169,7 @@ function handle_image_upgrade() {
       echo "  If you try subsequently to restart your instance it will fail until the updated image with"
       echo "  tag $SEED_IMAGE_VERSION is available in your system"
       echo "-------------------  WARNING  ----------------------"
-      local should_continue="n"
-      read -r -p "Continue with the upgrade process? [y/n] " should_continue
-      if [[ ! "$should_continue" =~ [Yy] ]]; then
-        echo "Exiting."
-        exit 1
-      fi
+      prompt "Continue with the upgrade process?"
     else
       set_git_bridge_image_name "$SEED_IMAGE_VERSION"
       docker pull "$GIT_BRIDGE_IMAGE"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -166,8 +166,8 @@ function handle_image_upgrade() {
       echo "  Upgrade of your custom image is skipped. You need to pull the image separately, making sure that:"
       echo "     1. The Docker image is tagged with the new version: $SEED_IMAGE_VERSION"
       echo "     2. The environment variable GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
-      echo "  You can safely proceed with the upgrade process, but if you try subsequently to restart your instance"
-      echo "  it will fail until the updated image with tag $SEED_IMAGE_VERSION is available in your system"
+      echo "  If you try subsequently to restart your instance it will fail until the updated image with"
+      echo "  tag $SEED_IMAGE_VERSION is available in your system"
       echo "-------------------  WARNING  ----------------------"
       local should_continue="n"
       read -r -p "Continue with the upgrade process? [y/n] " should_continue

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -166,10 +166,9 @@ function handle_image_upgrade() {
       echo "  Upgrade of your custom image is skipped. You need to pull the image separately, making sure that:"
       echo "     1. The Docker image is tagged with the new version: $SEED_IMAGE_VERSION"
       echo "     2. The config/overleaf.rc entry GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
-      echo "  If you try subsequently to restart your instance it will fail until the updated image with"
-      echo "  tag $SEED_IMAGE_VERSION is available in your system"
+      echo "  You wont be able to continue with this upgrade until you've tagged your custom image with $SEED_IMAGE_VERSION"
       echo "-------------------  WARNING  ----------------------"
-      prompt "Continue with the upgrade process?"
+      prompt "Have you tagged it?"
     fi
     set_git_bridge_image_name "$SEED_IMAGE_VERSION"
     docker pull "$GIT_BRIDGE_IMAGE"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -163,7 +163,7 @@ function handle_image_upgrade() {
     if [[ -n ${GIT_BRIDGE_IMAGE:-} ]]; then
       echo "-------------------  WARNING  ----------------------"
       echo "  You're using a custom git bridge image: $GIT_BRIDGE_IMAGE"
-      echo "  Upgrade of you're custom image is skipped. You need to pull the image separately, making sure that:"
+      echo "  Upgrade of your custom image is skipped. You need to pull the image separately, making sure that:"
       echo "     1. The Docker image is tagged with the new version: $SEED_IMAGE_VERSION"
       echo "     2. The environment variable GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
       echo "  You can safely proceed with the upgrade process, but if you try subsequently to restart your instance"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -165,7 +165,7 @@ function handle_image_upgrade() {
       echo "  You're using a custom git bridge image: $GIT_BRIDGE_IMAGE"
       echo "  Upgrade of your custom image is skipped. You need to pull the image separately, making sure that:"
       echo "     1. The Docker image is tagged with the new version: $SEED_IMAGE_VERSION"
-      echo "     2. The environment variable GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
+      echo "     2. The config/overleaf.rc entry GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
       echo "  If you try subsequently to restart your instance it will fail until the updated image with"
       echo "  tag $SEED_IMAGE_VERSION is available in your system"
       echo "-------------------  WARNING  ----------------------"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -170,10 +170,9 @@ function handle_image_upgrade() {
       echo "  tag $SEED_IMAGE_VERSION is available in your system"
       echo "-------------------  WARNING  ----------------------"
       prompt "Continue with the upgrade process?"
-    else
-      set_git_bridge_image_name "$SEED_IMAGE_VERSION"
-      docker pull "$GIT_BRIDGE_IMAGE"
     fi
+    set_git_bridge_image_name "$SEED_IMAGE_VERSION"
+    docker pull "$GIT_BRIDGE_IMAGE"
   fi
 
   ## Offer to stop docker services

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -162,13 +162,13 @@ function handle_image_upgrade() {
   if [[ $GIT_BRIDGE_ENABLED == "true" ]]; then
     if [[ -n ${GIT_BRIDGE_IMAGE:-} ]]; then
       echo "-------------------  WARNING  ----------------------"
-      echo "  You're using a custom git bridge image: $GIT_BRIDGE_IMAGE"
-      echo "  Upgrade of your custom image is skipped. You need to pull the image separately, making sure that:"
+      echo "  You're using the custom git bridge image $GIT_BRIDGE_IMAGE"
+      echo "  Before continuing you need to tag the updated image separately, making sure that:"
       echo "     1. The Docker image is tagged with the new version: $SEED_IMAGE_VERSION"
       echo "     2. The config/overleaf.rc entry GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
       echo "  You wont be able to continue with this upgrade until you've tagged your custom image with $SEED_IMAGE_VERSION"
       echo "-------------------  WARNING  ----------------------"
-      prompt "Have you tagged it?"
+      prompt "Has the custom image been tagged?"
     fi
     set_git_bridge_image_name "$SEED_IMAGE_VERSION"
     docker pull "$GIT_BRIDGE_IMAGE"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -160,8 +160,25 @@ function handle_image_upgrade() {
   set_server_pro_image_name "$SEED_IMAGE_VERSION"
   docker pull "$IMAGE"
   if [[ $GIT_BRIDGE_ENABLED == "true" ]]; then
-    set_git_bridge_image_name "$SEED_IMAGE_VERSION"
-    docker pull "$GIT_BRIDGE_IMAGE"
+    if [[ -n ${GIT_BRIDGE_IMAGE:-} ]]; then
+      echo "-------------------  WARNING  ----------------------"
+      echo "  You're using a custom git bridge image: $GIT_BRIDGE_IMAGE"
+      echo "  Upgrade of you're custom image is skipped. You need to pull the image separately, making sure that:"
+      echo "     1. The Docker image is tagged with the new version: $SEED_IMAGE_VERSION"
+      echo "     2. The environment variable GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
+      echo "  You can safely proceed with the upgrade process, but if you try subsequently to restart your instance"
+      echo "  it will fail until the updated image with tag $SEED_IMAGE_VERSION is available in your system"
+      echo "-------------------  WARNING  ----------------------"
+      local should_continue="n"
+      read -r -p "Continue with the upgrade process? [y/n] " should_continue
+      if [[ ! "$should_continue" =~ [Yy] ]]; then
+        echo "Exiting."
+        exit 1
+      fi
+    else
+      set_git_bridge_image_name "$SEED_IMAGE_VERSION"
+      docker pull "$GIT_BRIDGE_IMAGE"
+    fi
   fi
 
   ## Offer to stop docker services

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -96,7 +96,15 @@ function set_git_bridge_image_name() {
   else
     image_name="quay.io/sharelatex/git-bridge"
   fi
-  export GIT_BRIDGE_IMAGE="$image_name:$version"
+
+  # since we're reusing the GIT_BRIDGE_IMAGE environment variable, we check here if the version
+  # has already been added to it, for scenarios where this function is called more than once
+  if [[ "$image_name" == *"$version" ]]; then
+    export GIT_BRIDGE_IMAGE="$image_name"
+  else
+    export GIT_BRIDGE_IMAGE="$image_name:$version"
+  fi
+
 }
 
 function check_retracted_version() {


### PR DESCRIPTION
## Description

After the changes in:
- https://github.com/overleaf/toolkit/pull/300
- https://github.com/overleaf/toolkit/pull/304

there's a conflict running `bin/upgrade` when a custom git bridge image set with `GIT_BRIDGE_IMAGE` has its tag defined, which is no longer valid.

With the changes in this PR the `bin/upgrade` scripts no longer downloads automatically a new custom image, but prompts the admin to do it themselves separately (and make sure `GIT_BRIDGE_IMAGE` doesn't contain a tag).

An alternative implementation could check whether the tag is defined in  `GIT_BRIDGE_IMAGE`, but I opted for this solution due to:

- Checking for a tag existence is not that straighforward (image names can contain colons if they includes a host)
- Admins probably need to perform tagging separately, it's very unlikely they have the updated tag in their private registry to pull.

Cc @mlevans0 

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
