### PR TITLE
Tighten SSL security on nginx proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2024-11-18
+### Added
+- When a custom `GIT_BRIDGE_IMAGE` is set, `bin/upgrade` no longer tries to pull the new version, and prompts
+  the user to update and tag the custom image separately.
+- Tighten SSL security on nginx proxy
+
 ## 2024-10-29
 ### Added
 - Pull new images from `bin/upgrade` ahead of stopping containers

--- a/lib/config-seed/nginx.conf
+++ b/lib/config-seed/nginx.conf
@@ -15,11 +15,11 @@ http {
         ssl_certificate      /certs/nginx_certificate.pem;
         ssl_certificate_key  /certs/nginx_key.pem;
 
-        ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
-        ssl_prefer_server_ciphers   on;
-
-        # used cloudflares ciphers https://github.com/cloudflare/sslconfig/blob/master/conf
-        ssl_ciphers                 EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+        # Intermediate Mozilla Config
+        # https://ssl-config.mozilla.org/#server=nginx&version=1.26.0&config=intermediate&openssl=1.1.1w&ocsp=false&guideline=5.7
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+        ssl_prefer_server_ciphers off;
 
         # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
         # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping	


### PR DESCRIPTION
## Description

Updated nginx configuration in config-seed using [Mozilla recommendations](https://ssl-config.mozilla.org/#server=nginx&version=1.26.0&config=intermediate&openssl=1.1.1w&ocsp=false&guideline=5.7).  


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
