### PR TITLE
docs: update docker-compose documentation url in configuration.md

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -55,4 +55,4 @@ The `config/version` file contains the version number of the docker images that 
 
 If present, the `config/docker-compose.override.yml` file will be included in the invocation to `docker compose`. This is useful for overriding configuration specific to docker compose.
 
-See the [docker-compose documentation](https://docs.docker.com/compose/extends/#adding-and-overriding-configuration) for more details.
+See the [docker-compose documentation](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/) for more details.


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
Change the docker-compose documentation url to the correct one. It should be Merge Compose files instead of extend.

See also https://github.com/overleaf/toolkit/blob/7f10105a9be889d29e3f30a7e7733f678f8c1002/bin/docker-compose#L54-L57

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
