### PR TITLE
Add config option for skipping docker pull before upgrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-01-06
+### Added
+- Add new config option for skipping docker pull before upgrading
+- Document config options for air-gapped setups
+
 ## 2024-11-18
 ### Added
 - When a custom `GIT_BRIDGE_IMAGE` is set, `bin/upgrade` no longer tries to pull the new version, and prompts

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -156,22 +156,24 @@ function handle_image_upgrade() {
     prompt "Are you following the recovery process?"
   fi
 
-  echo "Pulling new images"
-  set_server_pro_image_name "$SEED_IMAGE_VERSION"
-  docker pull "$IMAGE"
-  if [[ $GIT_BRIDGE_ENABLED == "true" ]]; then
-    if [[ -n ${GIT_BRIDGE_IMAGE:-} ]]; then
-      echo "-------------------  WARNING  ----------------------"
-      echo "  You're using the custom git bridge image $GIT_BRIDGE_IMAGE"
-      echo "  Before continuing you need to tag the updated image separately, making sure that:"
-      echo "     1. The Docker image is tagged with the new version: $SEED_IMAGE_VERSION"
-      echo "     2. The config/overleaf.rc entry GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
-      echo "  You wont be able to continue with this upgrade until you've tagged your custom image with $SEED_IMAGE_VERSION"
-      echo "-------------------  WARNING  ----------------------"
-      prompt "Has the custom image been tagged?"
+  if [[ "${PULL_BEFORE_UPGRADE:-true}" == "true" ]]; then
+    echo "Pulling new images"
+    set_server_pro_image_name "$SEED_IMAGE_VERSION"
+    docker pull "$IMAGE"
+    if [[ $GIT_BRIDGE_ENABLED == "true" ]]; then
+      if [[ -n ${GIT_BRIDGE_IMAGE:-} ]]; then
+        echo "-------------------  WARNING  ----------------------"
+        echo "  You're using the custom git bridge image $GIT_BRIDGE_IMAGE"
+        echo "  Before continuing you need to tag the updated image separately, making sure that:"
+        echo "     1. The Docker image is tagged with the new version: $SEED_IMAGE_VERSION"
+        echo "     2. The config/overleaf.rc entry GIT_BRIDGE_IMAGE only contains the image name, and not a tag/version."
+        echo "  You wont be able to continue with this upgrade until you've tagged your custom image with $SEED_IMAGE_VERSION"
+        echo "-------------------  WARNING  ----------------------"
+        prompt "Has the custom image been tagged?"
+      fi
+      set_git_bridge_image_name "$SEED_IMAGE_VERSION"
+      docker pull "$GIT_BRIDGE_IMAGE"
     fi
-    set_git_bridge_image_name "$SEED_IMAGE_VERSION"
-    docker pull "$GIT_BRIDGE_IMAGE"
   fi
 
   ## Offer to stop docker services

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -16,3 +16,5 @@ If you do choose to switch versions, the script will then walk you through a pro
 The whole process looks like this:
 
 ![Demonstration of the upgrade script](./img/upgrade-demo.gif)
+
+> Note: For air-gapped setups that manually import docker images, please set `PULL_BEFORE_UPGRADE=false` in your `config/overleaf.rc` file.

--- a/lib/config-seed/overleaf.rc
+++ b/lib/config-seed/overleaf.rc
@@ -41,3 +41,7 @@ NGINX_TLS_LISTEN_IP=127.0.1.1
 TLS_PRIVATE_KEY_PATH=config/nginx/certs/overleaf_key.pem
 TLS_CERTIFICATE_PATH=config/nginx/certs/overleaf_certificate.pem
 TLS_PORT=443
+
+# In Air-gapped setups, skip pulling images
+# PULL_BEFORE_UPGRADE=false
+# SIBLING_CONTAINERS_PULL=false


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Follow-up for #304
For https://github.com/overleaf/internal/issues/21791#issuecomment-2482893874

This PR fixes the `bin/upgrade` process for air-gapped setups.

Best reviewed with white-space changes ignored due to indentation changes.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Follow-up for #304
For https://github.com/overleaf/internal/issues/21791#issuecomment-2482893874


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
