### PR TITLE
fix bin/up with mongo change

### DIFF
--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -223,5 +223,5 @@ function read_variable() {
 function read_configuration() {
   local name=$1
   grep -E "^$name=" "$TOOLKIT_ROOT/config/overleaf.rc" \
-  | sed -r "s/^$name=([\"']?)(.+)\1\$/\2/"
+  | sed -r "s/^$name=([\"']?)(.+)\$/\2/"
 }


### PR DESCRIPTION
with #270 the prefix of the configuration shouldn't be in the return value.

On a new checkout I ran into 
 
```
---------------------  ERROR  -----------------------
  Invalid MONGO_VERSION: MONGO_VERSION=6.0

  MONGO_VERSION must start with the actual major version of mongo, followed by a dot.
  Example: MONGO_IMAGE=my.dockerhub.com/custom-mongo
           MONGO_VERSION=6.0-custom
---------------------  ERROR  -----------------------
```

removing `\1` fixed it.

## Description
<!-- Goal of the pull request -->


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->


## Contributor Agreement

- [ ] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
