### PR TITLE
fix: prevent Git Bash path corruption for Docker volumes

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -94,9 +94,9 @@ function set_base_vars() {
     HAS_WEB_API=true
   fi
 
-  OVERLEAF_IN_CONTAINER_DATA_PATH=/var/lib/overleaf
+  OVERLEAF_IN_CONTAINER_DATA_PATH=//var/lib/overleaf
   if [[ "$IMAGE_VERSION_MAJOR" -lt 5 ]]; then
-    OVERLEAF_IN_CONTAINER_DATA_PATH=/var/lib/sharelatex
+    OVERLEAF_IN_CONTAINER_DATA_PATH=//var/lib/sharelatex
   fi
 
   export GIT_BRIDGE_ENABLED


### PR DESCRIPTION
Refactor container data paths to use double-slash prefix (//var/...) to:  
- Avoid Git Bash's automatic POSIX-Windows path conversion  
- Fix critical mount error on Windows environments:   "Error: mount source path too many colons"  
- Maintain Linux container compatibility  
- Resolves Overleaf toolkit init failure when using Git Bash

## Description
A detailed description is provided in #379


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
#379 

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
