### PR TITLE
Fix graceful shutdown when TLS proxy is configured

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2025-08-14
 ### Changed
 - Upgrade default nginx version for TLS proxy to version 1.28. If you configured a custom `NGINX_IMAGE`, please upgrade it.
+- Fix graceful shutdown procedure with TLS proxy enabled.
+  Swap the dependency between the TLS proxy and Server Pro/CE container. This ensures that `bin/stop` will wait for the application container to stop before taking down the TLS proxy. Notably this ensures that connected users can flush their changes as part of the graceful shutdown procedure.
+  Please align your nginx config with the updated default configuration (added upstream, configure docker as resolver and switch proxy_pass to upstream) by comparing `config/nginx/nginx.conf` and `lib/config-seed/nginx.conf`.
 
 ## 2025-08-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix graceful shutdown procedure with TLS proxy enabled.
   Swap the dependency between the TLS proxy and Server Pro/CE container. This ensures that `bin/stop` will wait for the application container to stop before taking down the TLS proxy. Notably this ensures that connected users can flush their changes as part of the graceful shutdown procedure.
   Please align your nginx config with the updated default configuration (added upstream, configure docker as resolver and switch proxy_pass to upstream) by comparing `config/nginx/nginx.conf` and `lib/config-seed/nginx.conf`.
+- Automatically configure `OVERLEAF_SECURE_COOKIE`/`OVERLEAF_BEHIND_PROXY`/`OVERLEAF_TRUSTED_PROXY_IPS` for TLS proxy.
 
 ## 2025-08-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-08-14
+### Changed
+- Upgrade default nginx version for TLS proxy to version 1.28. If you configured a custom `NGINX_IMAGE`, please upgrade it.
+
 ## 2025-08-04
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.5.4`.
@@ -17,7 +21,7 @@
 ## 2025-05-28
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.5.1`.
-- 
+-
 ## 2025-05-28
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `5.5.0`.
@@ -112,9 +116,9 @@
 
 - `SIBLING_CONTAINERS_ENABLED` is now set to `true` for new installs in [`config-seed/overleaf.rc`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/overleaf.rc).
 
-  We strongly recommend enabling the [Sandboxed Compiles feature](https://github.com/overleaf/toolkit/blob/master/doc/sandboxed-compiles.md) 
+  We strongly recommend enabling the [Sandboxed Compiles feature](https://github.com/overleaf/toolkit/blob/master/doc/sandboxed-compiles.md)
   for existing installations as well.
- 
+
 - Added "--appendonly yes" configuration to redis.
 
   Redis persistence documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/
@@ -301,12 +305,12 @@
 ## 2023-06-29
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `4.0.3`.
-- 
+-
 
 ## 2023-06-08
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `4.0.2`.
-- 
+-
 ## 2023-05-30
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `4.0.1`.
@@ -398,7 +402,7 @@
 ## 2021-10-13
 ### Added
 - HTTP to HTTPS redirection.
-  - Listen mode of the `sharelatex` container now `localhost` only, so the value of `SHARELATEX_LISTEN_IP` must be set to the public IP address for direct container access. 
+  - Listen mode of the `sharelatex` container now `localhost` only, so the value of `SHARELATEX_LISTEN_IP` must be set to the public IP address for direct container access.
 
 ## 2021-08-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 - Upgrade default nginx version for TLS proxy to version 1.28. If you configured a custom `NGINX_IMAGE`, please upgrade it.
 - Fix graceful shutdown procedure with TLS proxy enabled.
   Swap the dependency between the TLS proxy and Server Pro/CE container. This ensures that `bin/stop` will wait for the application container to stop before taking down the TLS proxy. Notably this ensures that connected users can flush their changes as part of the graceful shutdown procedure.
-  Please align your nginx config with the updated default configuration (added upstream, configure docker as resolver and switch proxy_pass to upstream) by comparing `config/nginx/nginx.conf` and `lib/config-seed/nginx.conf`.
+  Please align your nginx config with the updated default configuration (add upstream, configure docker as resolver and switch proxy_pass to upstream) by comparing `config/nginx/nginx.conf` and `lib/config-seed/nginx.conf`.
 - Automatically configure `OVERLEAF_SECURE_COOKIE`/`OVERLEAF_BEHIND_PROXY`/`OVERLEAF_TRUSTED_PROXY_IPS` for TLS proxy.
+  In case you are using a subnet from `172.16.0.0/12` (default subnet for Docker networks) for your regular network, please set `OVERLEAF_TRUSTED_PROXY_IPS=loopback,<network>` in your `config/variables.env`. Where `<network>` is the `IPAM -> Config -> Subnet` value in `docker inspect overleaf_default`, e.g. `OVERLEAF_TRUSTED_PROXY_IPS=loopback,172.19.0.0/16`
+
+  Customers with an external TLS proxy (i.e. not managed by the Overleaf Toolkit), please ensure that `OVERLEAF_TRUSTED_PROXY_IPS=loopback,<ip-of-your-tls-proxy>` is set in your `config/variables.env`, e.g. `OVERLEAF_TRUSTED_PROXY_IPS=loopback,192.168.13.37`.
 
 ## 2025-08-04
 ### Added

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -180,6 +180,8 @@ function set_nginx_vars() {
   fi
   OVERLEAF_TRUSTED_PROXY_IPS=$(read_variable OVERLEAF_TRUSTED_PROXY_IPS || echo "")
   if [[ "${OVERLEAF_TRUSTED_PROXY_IPS:-null}" == "null" ]]; then
+    # https://en.wikipedia.org/wiki/Private_network
+    # Docker allocates subnets from 172.16.0.0/12 by default.
     OVERLEAF_TRUSTED_PROXY_IPS="loopback,172.16.0.0/12"
   fi
 

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -178,6 +178,10 @@ function set_nginx_vars() {
   if [[ -n ${NGINX_CONFIG_PATH-} ]]; then
     NGINX_CONFIG_PATH=$(cd "$TOOLKIT_ROOT"; realpath "$NGINX_CONFIG_PATH")
   fi
+  OVERLEAF_TRUSTED_PROXY_IPS=$(read_variable OVERLEAF_TRUSTED_PROXY_IPS || echo "")
+  if [[ "${OVERLEAF_TRUSTED_PROXY_IPS:-null}" == "null" ]]; then
+    OVERLEAF_TRUSTED_PROXY_IPS="loopback,172.16.0.0/12"
+  fi
 
   export NGINX_CONFIG_PATH
   export NGINX_IMAGE
@@ -187,6 +191,7 @@ function set_nginx_vars() {
   export TLS_CERTIFICATE_PATH
   export TLS_PORT
   export TLS_PRIVATE_KEY_PATH
+  export OVERLEAF_TRUSTED_PROXY_IPS
 }
 
 # Set environment variables for docker-compose.git-bridge.yml

--- a/doc/tls-proxy.md
+++ b/doc/tls-proxy.md
@@ -8,20 +8,6 @@ A default config for NGINX is provided in `config/nginx/nginx.conf` which may be
 
 In order for Overleaf to run correctly behind the proxy, the following variables should be uncommented in `config/variables.env`
 
-Since Overleaf CE/Server Pro `5.x`:
-
-```
-OVERLEAF_BEHIND_PROXY=true
-OVERLEAF_SECURE_COOKIE=true
-```
-
-For Overleaf CE/Server Pro `4.x` and older versions:
-
-```
-SHARELATEX_BEHIND_PROXY=true
-SHARELATEX_SECURE_COOKIE=true
-```
-
 Add the following section to your `config/overleaf.rc` file if it is not there already:
 ```
 # TLS proxy configuration (optional)

--- a/lib/config-seed/nginx.conf
+++ b/lib/config-seed/nginx.conf
@@ -1,6 +1,8 @@
 events {}
 
 http {
+    # 127.0.0.11 is the DNS server running in Docker. It can resolve the docker compose service name "sharelatex" to a container IP.
+    # https://github.com/docker/docs/issues/20532
     resolver 127.0.0.11 ipv6=off valid=10s;
     upstream sharelatex {
       zone dns 64k;

--- a/lib/config-seed/nginx.conf
+++ b/lib/config-seed/nginx.conf
@@ -1,6 +1,11 @@
 events {}
 
 http {
+    resolver 127.0.0.11 ipv6=off valid=10s;
+    upstream sharelatex {
+      zone dns 64k;
+      server sharelatex:80 resolve;
+    }
 
     server {
         listen 80 default_server;
@@ -22,7 +27,7 @@ http {
         ssl_prefer_server_ciphers off;
 
         # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
-        # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping	
+        # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
 
         server_tokens off;
@@ -30,7 +35,7 @@ http {
         client_max_body_size 50M;
 
         location / {
-            proxy_pass http://sharelatex:80;
+            proxy_pass http://sharelatex;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/lib/default.rc
+++ b/lib/default.rc
@@ -28,7 +28,7 @@ GIT_BRIDGE_LOG_LEVEL=INFO
 
 # TLS proxy configuration
 NGINX_ENABLED=false
-NGINX_IMAGE=nginx:1.19-alpine
+NGINX_IMAGE=nginx:1.28-alpine
 NGINX_CONFIG_PATH=config/nginx/nginx.conf
 NGINX_HTTP_PORT=80
 TLS_PORT=443

--- a/lib/docker-compose.nginx.yml
+++ b/lib/docker-compose.nginx.yml
@@ -1,5 +1,8 @@
 ---
 services:
+  sharelatex:
+    depends_on:
+      - nginx
 
   nginx:
     image: "${NGINX_IMAGE}"
@@ -12,5 +15,3 @@ services:
       - "${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf:ro"
     restart: always
     container_name: nginx
-    depends_on:
-      - sharelatex

--- a/lib/docker-compose.nginx.yml
+++ b/lib/docker-compose.nginx.yml
@@ -1,6 +1,12 @@
 ---
 services:
   sharelatex:
+    environment:
+      OVERLEAF_SECURE_COOKIE: 'true'
+      OVERLEAF_TRUSTED_PROXY_IPS: "${OVERLEAF_TRUSTED_PROXY_IPS}"
+      # Enabled by default in Server Pro 6.0
+      OVERLEAF_BEHIND_PROXY: 'true'
+
     depends_on:
       - nginx
 


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

- Part of https://github.com/overleaf/internal/issues/26252

This PR is fixing the long standing issue of a broken graceful shutdown procedure with the TLS proxy enabled. The proxy setup has also been updated for the upcoming 6.0 release.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

- Part of https://github.com/overleaf/internal/issues/26252

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
