### PR TITLE
Update link to CLA in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
 
 ## Contributor Agreement
 
-- [ ] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
+- [ ] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

- For Documentation Day 25.5
- Same as https://github.com/overleaf/internal/pull/27943

Point to the main branch for the CLA. The master branch is the old HEAD from 4 years ago.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

- For Documentation Day 25.5
- Same as https://github.com/overleaf/internal/pull/27943


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
