### PR TITLE
Fix regex in read_configuration function For MacOS

### DIFF
--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -223,5 +223,5 @@ function read_variable() {
 function read_configuration() {
   local name=$1
   grep -E "^$name=" "$TOOLKIT_ROOT/config/overleaf.rc" \
-  | sed -r "s/^$name=([\"']?)(.+)\1\$/\2/"
+  | cut -d '=' -f 2
 }


### PR DESCRIPTION

## Description

This pull request corrects a command in a setup script that fails to parse configuration values correctly on macOS. Specifically, when attempting to extract the MongoDB version from `config/overleaf.rc`, the existing `sed` command returns the entire line `MONGO_VERSION=7.0` instead of the required value `7.0`.

The issue originates from **fundamental differences between the GNU `sed` implementation (common on Linux) and the BSD `sed` implementation (used by macOS)**. The script's regular expression relies on behavior specific to GNU `sed`, causing the substitution to fail silently on macOS.

To resolve this and enhance script portability, this change **replaces the non-portable `sed` command with the universally available `cut` command**. The modified pipeline continues to use `grep` to isolate the target line, but then passes the result to `cut`. Using the equals sign `=` as a delimiter, `cut` cleanly extracts the version value. This approach is simple, avoids the complexities of cross-platform regular expressions, and **guarantees consistent behavior** across both Linux and macOS environments.

## Related issues / Pull Requests

Fixes a developer setup issue on macOS where environment variables are not parsed correctly.

## Contributor Agreement

- [ √] I confirm I have signed the [[Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)