### PR TITLE
Disable telemetry collection in `mongosh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-02-11
+### Added
+- Disable telemetry data collection in `mongosh`.
+
 ## 2026-02-02
 ### Added
 - Updated default [`version`](https://github.com/overleaf/toolkit/blob/master/lib/config-seed/version) to `6.1.1`.

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -143,6 +143,7 @@ function set_mongo_vars() {
   export MONGO_DATA_PATH
   export MONGO_DOCKER_IMAGE
   export MONGOSH
+  export TOOLKIT_ROOT
 }
 
 # Set environment variables for docker-compose.sibling-containers.yml

--- a/lib/docker-compose.mongo.yml
+++ b/lib/docker-compose.mongo.yml
@@ -8,6 +8,7 @@ services:
         container_name: mongo
         volumes:
             - "${MONGO_DATA_PATH}:/data/db"
+            - "${TOOLKIT_ROOT}/lib/mongosh.conf:/etc/mongosh.conf"
         expose:
             - 27017
         healthcheck:

--- a/lib/mongosh.conf
+++ b/lib/mongosh.conf
@@ -1,0 +1,2 @@
+mongosh:
+  forceDisableTelemetry: true


### PR DESCRIPTION
## Description

This PR disables telemetry collection in `mongosh` by adding a [global mongo config file](https://www.mongodb.com/docs/mongodb-shell/reference/configure-shell-settings-global/). I'm using `forceDisableTelemetry` to override any local configuration.

Tests:

```
overleaf [direct: primary] sharelatex> config.set("enableTelemetry", true)
MongoshRuntimeError: Cannot modify telemetry settings while 'forceDisableTelemetry' is set to true
overleaf [direct: primary] sharelatex> disableTelemetry()
MongoshRuntimeError: Cannot modify telemetry settings while 'forceDisableTelemetry' is set to true
overleaf [direct: primary] sharelatex> enableTelemetry()
MongoshRuntimeError: Cannot modify telemetry settings while 'forceDisableTelemetry' is set to true
```





## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
