### PR TITLE
Fix selinux labeling issues of docker volume mounts

### DIFF
--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -1,21 +1,20 @@
 ---
 services:
-
-    sharelatex:
-        restart: always
-        image: "${IMAGE}"
-        container_name: sharelatex
-        volumes:
-            - "${OVERLEAF_DATA_PATH}:${OVERLEAF_IN_CONTAINER_DATA_PATH}"
-        ports:
-            - "${OVERLEAF_LISTEN_IP:-127.0.0.1}:${OVERLEAF_PORT:-80}:80"
-        environment:
-          GIT_BRIDGE_ENABLED: "${GIT_BRIDGE_ENABLED}"
-          GIT_BRIDGE_HOST: "git-bridge"
-          GIT_BRIDGE_PORT: "8000"
-          REDIS_HOST: "${REDIS_HOST}"
-          REDIS_PORT: "${REDIS_PORT}"
-          V1_HISTORY_URL: "http://sharelatex:3100/api"
-        env_file:
-            - ../config/variables.env
-        stop_grace_period: 60s
+  sharelatex:
+    restart: always
+    image: "${IMAGE}"
+    container_name: sharelatex
+    volumes:
+      - "${OVERLEAF_DATA_PATH}:${OVERLEAF_IN_CONTAINER_DATA_PATH}:Z"
+    ports:
+      - "${OVERLEAF_LISTEN_IP:-127.0.0.1}:${OVERLEAF_PORT:-80}:80"
+    environment:
+      GIT_BRIDGE_ENABLED: "${GIT_BRIDGE_ENABLED}"
+      GIT_BRIDGE_HOST: "git-bridge"
+      GIT_BRIDGE_PORT: "8000"
+      REDIS_HOST: "${REDIS_HOST}"
+      REDIS_PORT: "${REDIS_PORT}"
+      V1_HISTORY_URL: "http://sharelatex:3100/api"
+    env_file:
+      - ../config/variables.env
+    stop_grace_period: 60s

--- a/lib/docker-compose.mongo.yml
+++ b/lib/docker-compose.mongo.yml
@@ -7,7 +7,7 @@ services:
         command: "${MONGO_ARGS}"
         container_name: mongo
         volumes:
-            - "${MONGO_DATA_PATH}:/data/db"
+            - "${MONGO_DATA_PATH}:/data/db:Z"
         expose:
             - 27017
         healthcheck:

--- a/lib/docker-compose.redis.yml
+++ b/lib/docker-compose.redis.yml
@@ -5,7 +5,7 @@ services:
         restart: always
         image: "${REDIS_IMAGE}"
         volumes:
-            - "${REDIS_DATA_PATH}:/data"
+            - "${REDIS_DATA_PATH}:/data:Z"
         container_name: redis
         command: ${REDIS_COMMAND}
         expose:


### PR DESCRIPTION
## Description
This pull Request fixes issues on linux systems with *selinux* installed. It uses A Standard Docker feature which enables selinux to correctly infer security labels for volume mounts created by docker on the local os.

> Two suffixes :z or :Z can be added to the volume mount. These suffixes tell Docker to relabel file objects on the shared volumes. The 'z' option tells Docker that the volume content will be shared between containers. Docker will label the content with a shared content label. Shared volumes labels allow all containers to read/write content. The 'Z' option tells Docker to label the content with a private unshared label. Private volumes can only be used by the current container.


## Related issues / Pull Requests

Partly solves existing issue with podman (since selinux is often also present) https://github.com/overleaf/toolkit/issues/330

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
