### PR TITLE
Fix MongoDB crash on kernel newer than 6.19

### DIFF
--- a/lib/config-seed/overleaf.rc
+++ b/lib/config-seed/overleaf.rc
@@ -18,7 +18,7 @@ DOCKER_SOCKET_PATH=/var/run/docker.sock
 MONGO_ENABLED=true
 MONGO_DATA_PATH=data/mongo
 MONGO_IMAGE=mongo
-MONGO_VERSION=8.0
+MONGO_VERSION=8.0.4
 
 # Redis configuration
 REDIS_ENABLED=true


### PR DESCRIPTION
## Description
Addresses the issue MongoDB 8.0 has with newer than 6.19 kernels. I've found a post (https://www.mongodb.com/community/forums/t/mongodb-8-x-and-linux-kernel-6-19/337547) on the MongoDB forum which has lead me to the solution.

The only change made is to upgrade the MongoDB version from 8.0 to 8.0.4.
I only validated this on my system which has kernel version 7.0.13.


## Related issues / Pull Requests
Fixes #431


## Contributor Agreement

- [ x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
