### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ git clone https://github.com/overleaf/toolkit.git ./overleaf-toolkit
 
 Then follow the [Quick Start Guide](./doc/quick-start-guide.md).
 
+For a community-maintained alternative deployment, [deploy Overleaf Community Edition on Sealos](https://sealos.io/products/app-store/overleaf).
+
 
 ## Documentation
 


### PR DESCRIPTION
## Description

Adds a short installation note linking to a community-maintained Sealos deployment for Overleaf Community Edition. The Toolkit quick-start path remains unchanged, and this PR changes documentation only.

## Related issues / Pull Requests

No related issue.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)

## Validation

- Sealos App Store URL: https://sealos.io/products/app-store/overleaf (HTTP 200)
- Deployment template image: `sharelatex/sharelatex:5.0.6`
- Deployment tested on 2026-08-05 with persistent `/var/lib/overleaf` storage and MongoDB/Redis services
- Community Edition security boundary remains documented by Overleaf; the link does not claim Server Pro support
- `git diff --check` passes

## Maintenance

The Sealos template is maintained separately, and I can follow up if the deployment link or template needs an update.