### PR TITLE
Add rootless Podman support (RHEL 9+, SELinux, sibling containers)

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -138,28 +138,141 @@ function check_dependencies() {
 }
 
 function check_docker_daemon() {
-  print_point 0 "Docker Daemon"
-  if docker ps &>/dev/null;  then
-    print_point 1 "status: up"
+  print_point 0 "Container Daemon"
 
-    local docker_server_version=$(docker version -f '{{.Server.Version}}')
+  local using_podman=false
+  if is_podman; then
+    using_podman=true
+  fi
+
+  if docker ps &>/dev/null; then
+    print_point 1 "status: up"
+    print_point 1 "runtime: $([[ "$using_podman" == true ]] && echo "podman" || echo "docker")"
+
+    local docker_server_version
+    docker_server_version=$(docker version -f '{{.Server.Version}}' 2>/dev/null || echo "unknown")
     print_point 1 "server version: $docker_server_version"
-    if [[ "$docker_server_version" =~ ^([0-9]+)\.([0-9]+) ]]; then
-      local major="${BASH_REMATCH[1]}"
-      local minor="${BASH_REMATCH[2]}"
-      if [[ "$major" -lt 23 ]]; then
-        add_warning "Docker v$major.$minor has reached its End Of Life. We recommend upgrading to a supported version."
+
+    if [[ "$using_podman" == false ]]; then
+      if [[ "$docker_server_version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+        local major="${BASH_REMATCH[1]}"
+        local minor="${BASH_REMATCH[2]}"
+        if [[ "$major" -lt 23 ]]; then
+          add_warning "Docker v$major.$minor has reached its End Of Life. We recommend upgrading to a supported version."
+        fi
+      else
+        add_warning "Docker server version unknown ($docker_server_version)"
       fi
-    else
-      add_warning "Docker server version unknown ($docker_server_version)"
     fi
 
-    if docker info | grep -q -e '/var/snap/docker/common/var-lib-docker'; then
+    if docker info 2>/dev/null | grep -q -e '/var/snap/docker/common/var-lib-docker'; then
       add_warning "Installing Docker via snap is not supported. The sandboxed compiles feature may not be available. Please follow the steps for installing Docker CE on https://docs.docker.com/engine/install/."
     fi
   else
     print_point 1 "status: DOWN !"
     add_warning "Docker daemon is not running"
+  fi
+
+  local socket_path=""
+
+  if [[ -f "$TOOLKIT_ROOT/config/overleaf.rc" ]]; then
+    # shellcheck disable=SC1090
+    source "$TOOLKIT_ROOT/config/overleaf.rc"
+  fi
+
+  resolve_socket_path
+  socket_path="$RESOLVED_SOCKET_PATH"
+
+  if [[ -n "$socket_path" ]]; then
+    print_point 1 "socket: $socket_path"
+  else
+    print_point 1 "socket: not found"
+  fi
+
+  if [[ "${SERVER_PRO:-false}" == "true" && "${SIBLING_CONTAINERS_ENABLED:-false}" == "true" && -n "$socket_path" ]]; then
+    if [[ "$using_podman" == true ]]; then
+      if [[ -n "${DOCKER_HOST:-}" ]]; then
+        print_point 1 "DOCKER_HOST: $DOCKER_HOST"
+      elif [[ -f "$TOOLKIT_ROOT/config/overleaf.rc" ]] && grep -q "^DOCKER_HOST=" "$TOOLKIT_ROOT/config/overleaf.rc" 2>/dev/null; then
+        local rc_docker_host
+        rc_docker_host=$(grep "^DOCKER_HOST=" "$TOOLKIT_ROOT/config/overleaf.rc" | head -1 | sed 's/^DOCKER_HOST=//' | sed 's/["'"'"']//g')
+        print_point 1 "DOCKER_HOST: $rc_docker_host"
+      else
+        print_point 1 "DOCKER_HOST: not set"
+        add_warning "DOCKER_HOST not set — ./bin/up will look for the default Docker socket"
+      fi
+
+      if [[ -f "$TOOLKIT_ROOT/config/variables.env" ]] && grep -q "DOCKER_HOST" "$TOOLKIT_ROOT/config/variables.env" 2>/dev/null; then
+        add_warning "DOCKER_HOST found in variables.env — it needs to be set in overleaf.rc instead"
+      fi
+    fi
+
+    if [[ ! -S "$socket_path" ]]; then
+      add_warning "Configured socket path '$socket_path' does not exist or is not a socket"
+    else
+      if [[ "$using_podman" == true ]] && command -v getenforce &>/dev/null; then
+        local enforce
+        enforce=$(getenforce 2>/dev/null || echo "Disabled")
+        print_point 1 "SELinux: $enforce"
+
+        if [[ "$enforce" != "Disabled" ]]; then
+          check_selinux_module "sudo -n"
+          if [[ "$SELINUX_MODULE_LOADED" == true ]]; then
+            print_point 1 "SELinux module: present (podman_socket_clsi)"
+            check_selinux_rules "sudo -n"
+            if [[ "$SELINUX_RULES_OK" == false ]]; then
+              for rule in "${SELINUX_MISSING_RULES[@]}"; do
+                print_point 2 "rule MISSING: $rule"
+              done
+              add_warning "SELinux policy module podman_socket_clsi is missing required rules. Container cannot connect to Podman socket."
+            fi
+          else
+            print_point 1 "SELinux module (podman_socket_clsi): not found"
+            add_warning "SELinux is Enforcing but the podman_socket_clsi module is not loaded. The sharelatex container will be blocked from connecting to the Podman socket."
+          fi
+        fi
+      fi
+
+      test_socket_ping_host "$socket_path"
+      if [[ "$SOCKET_PING_HOST_OK" == true ]]; then
+        print_point 1 "host → socket: OK"
+      else
+        print_point 1 "host → socket: FAILED ($SOCKET_PING_HOST_OUTPUT)"
+        add_warning "Cannot connect to Docker/Podman socket from host"
+      fi
+
+      test_socket_ping_container
+      if [[ "$SOCKET_PING_CONTAINER_OK" == true ]]; then
+        print_point 1 "container → socket: OK"
+      elif [[ "$SOCKET_PING_CONTAINER_OUTPUT" == "sharelatex not running" ]]; then
+        print_point 1 "container → socket: skipped (sharelatex not running)"
+      else
+        print_point 1 "container → socket: FAILED ($SOCKET_PING_CONTAINER_OUTPUT)"
+        add_warning "sharelatex container cannot connect to the Docker/Podman socket at /var/run/docker.sock"
+      fi
+    fi
+  fi
+
+  if [[ "$using_podman" == true ]]; then
+    local seccomp_path
+    seccomp_path="$(get_seccomp_expected_path)"
+    check_seccomp_config
+
+    if [[ "$SECCOMP_FILE_EXISTS" == true && "$SECCOMP_ENV_MATCHES" == true ]]; then
+      print_point 1 "Seccomp profile: present"
+    else
+      if [[ "$SECCOMP_FILE_EXISTS" == false ]]; then
+        print_point 1 "Seccomp profile: MISSING (file not found at $seccomp_path)"
+        add_warning "Seccomp profile not installed at $seccomp_path"
+      fi
+      if [[ -z "$SECCOMP_ENV_VALUE" ]]; then
+        print_point 1 "SECCOMP_PROFILE: not set"
+        add_warning "SECCOMP_PROFILE not set in variables.env"
+      elif [[ "$SECCOMP_ENV_MATCHES" == false ]]; then
+        print_point 1 "SECCOMP_PROFILE: '$SECCOMP_ENV_VALUE' (expected '$seccomp_path')"
+        add_warning "SECCOMP_PROFILE should be '$seccomp_path'"
+      fi
+    fi
   fi
 }
 
@@ -222,18 +335,16 @@ function check_config_files() {
           add_warning "Detected SIBLING_CONTAINERS_ENABLED=false. When not using Sibling containers, users have full read and write access to the 'sharelatex' container resources (filesystem, network, environment variables) when running LaTeX compiles. Only use this mode in environments where all users are trusted and no isolation of users is required."
         fi
         if [[ "${SERVER_PRO:-null}" == "true" ]]; then
-          local logged_in
-          logged_in="$(grep -q quay.io ~/.docker/config.json && echo 'true' || echo 'false')"
-          print_point 3 "logged in to quay.io: $logged_in"
-          if [[ "${logged_in}" == "false" ]]; then
-            local warning_message=(
-              "Server Pro enabled, but not logged in to quay.io repository."
-              "These credentials are supplied by Overleaf with a Server Pro"
-              "license. See https://www.overleaf.com/for/enterprises/features"
-              "for more details about Server Pro, or contact support@overleaf.com"
-              "if you have any questions."
-            )
-            add_warning "${warning_message[@]}"
+          check_quay_login
+          if [[ "$QUAY_LOGIN_STATUS" == true ]]; then
+            if [[ -n "$QUAY_LOGIN_USER" ]]; then
+              print_point 3 "logged in to quay.io: true ($QUAY_LOGIN_USER)"
+            else
+              print_point 3 "logged in to quay.io: true"
+            fi
+          else
+            print_point 3 "logged in to quay.io: false"
+            add_warning "Server Pro enabled, but not logged in to quay.io repository. These credentials are supplied by Overleaf with a Server Pro license. See https://www.overleaf.com/for/enterprises/features for more details about Server Pro, or contact support@overleaf.com if you have any questions."
           fi
         elif [[ "${SIBLING_CONTAINERS_ENABLED:-null}" == "true" ]]; then
           add_warning "Sibling containers are not available in Community Edition, which is intended for use in environments where all users are trusted. Community Edition is not appropriate for scenarios where isolation of users is required. Sibling containers are offered as part of our Server Pro offering and you can read more about the differences at https://www.overleaf.com/for/enterprises/features. Set SIBLING_CONTAINERS_ENABLED=false in config/overleaf.rc to continue using insecure in-container compiles."

--- a/bin/podman-setup
+++ b/bin/podman-setup
@@ -1,0 +1,615 @@
+#! /usr/bin/env bash
+# shellcheck source-path=..
+# Overleaf Server Pro -- Podman Setup
+# Validates and auto-fixes a RHEL-based system for use with Overleaf Server Pro
+# rootless Podman, sibling containers and SELinux enforcing.
+#
+# Part of the overleaf-toolkit. Invoked via:
+#   ./bin/podman-setup [--apply]
+# Exit codes: 0 = all clear, 1 = warnings, 2 = failures
+
+set -euo pipefail
+
+#### Detect Toolkit Project Root ####
+command -v realpath >/dev/null 2>&1 || realpath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+TOOLKIT_ROOT="$(realpath "$(dirname "$SCRIPT_PATH")/..")"
+
+if [[ ! -d "$TOOLKIT_ROOT/bin" ]] || [[ ! -d "$TOOLKIT_ROOT/config" ]]; then
+  echo "ERROR: could not find root of overleaf-toolkit project"
+  exit 1
+fi
+
+if [[ ! -f "$TOOLKIT_ROOT/config/overleaf.rc" ]] || [[ ! -f "$TOOLKIT_ROOT/config/variables.env" ]] || [[ ! -f "$TOOLKIT_ROOT/config/version" ]]; then
+  echo "ERROR: Toolkit not initialized. Run 'bin/init' first."
+  exit 1
+fi
+
+source "$TOOLKIT_ROOT/lib/shared-functions.sh"
+
+validate_os() {
+  [[ -f /etc/os-release ]] || { echo "ERROR: /etc/os-release missing"; exit 1; }
+
+  local id version_id
+  # shellcheck disable=SC1091
+  read -r id version_id < <(. /etc/os-release && echo "${ID} ${VERSION_ID%%.*}")
+
+  case "$id" in
+    centos|rhel|rocky|almalinux)
+      [[ "$version_id" -ge 9 ]] && return 0
+      ;;
+  esac
+  echo "ERROR: unsupported OS '${id} ${version_id}'. RHEL 9+ required."
+  exit 1
+}
+
+validate_os
+
+USER_NAME="$(id -un)"
+USER_UID="$(id -u)"
+DRY_RUN=true
+
+declare -i CHECK_PASS=0 CHECK_WARN=0 CHECK_FAIL=0
+SUMMARY=""
+
+REQUIRED_PKGS=(podman podman-docker git curl checkpolicy policycoreutils)
+
+report() {
+  local level="$1" msg="$2"
+  case "$level" in
+    ok)   CHECK_PASS+=1; printf "[✓] %s\n" "$msg" ;;
+    warn) CHECK_WARN+=1; SUMMARY+="[!] $msg"$'\n'; printf "[!] %s\n" "$msg" >&2 ;;
+    fail) CHECK_FAIL+=1; SUMMARY+="[✗] $msg"$'\n'; printf "[✗] %s\n" "$msg" >&2 ;;
+    fix)  printf "[*] %s\n" "$msg" ;;
+    skip) printf "[-] %s\n" "$msg" ;;
+  esac
+}
+
+heading() { printf "\n====== %s ======\n" "$1"; }
+
+is_dry_run() { [ "$DRY_RUN" = true ]; }
+is_apply() { [ "$DRY_RUN" = false ]; }
+
+run_sudo() {
+  if sudo -n true 2>/dev/null; then
+    sudo "$@"
+  elif is_dry_run; then
+    report warn "Cannot run 'sudo $*' (password required, use --apply)"
+    return 1
+  else
+    sudo "$@"
+  fi
+}
+
+get_podman_socket_path() {
+  echo "/run/user/${USER_UID}/podman/podman.sock"
+}
+
+ensure_lingering() {
+  heading "Lingering"
+  local desc="lingering enabled for $USER_NAME"
+
+  if loginctl show-user "$USER_NAME" -p Linger --value 2>/dev/null | grep -q yes; then
+    report ok "$desc"
+    return 0
+  fi
+
+  if is_dry_run; then
+    report warn "$desc missing"
+    return 1
+  fi
+
+  if run_sudo loginctl enable-linger "$USER_NAME"; then
+    report fix "$desc configured"
+  else
+    report fail "$desc"
+    return 1
+  fi
+}
+
+ensure_packages() {
+  heading "Packages"
+  local missing=()
+
+  for pkg in "${REQUIRED_PKGS[@]}"; do
+    if rpm -q "$pkg" &>/dev/null; then
+      report ok "$pkg installed"
+    else
+      report fail "$pkg missing"
+      missing+=("$pkg")
+    fi
+  done
+
+  if is_apply && [ ${#missing[@]} -gt 0 ]; then
+    if run_sudo dnf install -y "${missing[@]}"; then
+      report fix "installed ${missing[*]}"
+    else
+      report fail "dnf install"
+    fi
+  fi
+}
+
+ensure_podman_socket() {
+  heading "Services"
+
+  if systemctl --user is-active podman.socket &>/dev/null; then
+    report ok "podman.socket active"
+    return 0
+  fi
+
+  if is_dry_run; then
+    report fail "podman.socket inactive"
+    return 1
+  fi
+
+  if systemctl --user enable --now podman.socket; then
+    report fix "enabled podman.socket"
+  else
+    report fail "podman.socket"
+  fi
+}
+
+
+read_config_var() {
+  local var_name="$1" file="$2"
+  grep "^${var_name}=" "$file" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d ' ' || true
+}
+
+set_config_var() {
+  local var_name="$1" expected="$2" file="$3"
+  if grep -q "^${var_name}=" "$file" 2>/dev/null; then
+    sed -i "s|^${var_name}=.*|${var_name}=${expected}|" "$file"
+  else
+    echo "${var_name}=${expected}" >> "$file"
+  fi
+}
+
+remove_config_var() {
+  local var_name="$1" file="$2"
+  sed -i "/^${var_name}=/d" "$file" 2>/dev/null || true
+}
+
+ensure_config_var() {
+  local var_name="$1" expected="$2" rc_file="$3" wrong_file="${4:-}"
+
+  local current
+  current="$(read_config_var "$var_name" "$rc_file")"
+
+  if [ "$current" = "$expected" ]; then
+    report ok "${var_name} correct"
+  elif [ -n "$current" ]; then
+    if is_dry_run; then
+      report warn "${var_name} is '$current', expected '$expected'"
+    else
+      set_config_var "$var_name" "$expected" "$rc_file"
+      report fix "${var_name} corrected"
+    fi
+  else
+    if is_dry_run; then
+      report warn "${var_name} not set"
+    else
+      set_config_var "$var_name" "$expected" "$rc_file"
+      report fix "added ${var_name}"
+    fi
+  fi
+
+  if [ -n "$wrong_file" ] && grep -q "^${var_name}=" "$wrong_file" 2>/dev/null; then
+    if is_dry_run; then
+      report fail "${var_name} must not be in $(basename "$wrong_file")"
+    else
+      remove_config_var "$var_name" "$wrong_file"
+      report fix "removed ${var_name} from $(basename "$wrong_file")"
+    fi
+  fi
+}
+
+ensure_docker_host() {
+  local sock_path expected
+  sock_path="$(get_podman_socket_path)"
+  expected="unix://${sock_path}"
+  ensure_config_var "DOCKER_HOST" "$expected" \
+    "$TOOLKIT_ROOT/config/overleaf.rc" "$TOOLKIT_ROOT/config/variables.env"
+}
+
+ensure_docker_socket() {
+  local sock_path
+  sock_path="$(get_podman_socket_path)"
+  ensure_config_var "DOCKER_SOCKET_PATH" "$sock_path" \
+    "$TOOLKIT_ROOT/config/overleaf.rc" "$TOOLKIT_ROOT/config/variables.env"
+}
+
+ensure_docker_compose() {
+  local compose_bin="$HOME/.local/bin/docker-compose"
+  local compose_plugin="$HOME/.docker/cli-plugins/docker-compose"
+
+  if [ -x "$compose_bin" ]; then
+    local version
+    version="$($compose_bin version 2>/dev/null | head -1 || echo "installed")"
+    report ok "Docker Compose: $version"
+  elif is_dry_run; then
+    report fail "Docker Compose missing"
+    return 1
+  else
+    mkdir -p "$HOME/.local/bin" "$HOME/.docker/cli-plugins"
+
+    local base_url="https://github.com/docker/compose/releases/latest/download"
+    local binary="docker-compose-$(uname -s)-$(uname -m)"
+    local tmp_bin tmp_sum rc=0
+    tmp_bin="$(mktemp)"
+    tmp_sum="$(mktemp)"
+
+    if ! curl -sL "${base_url}/${binary}" -o "$tmp_bin"; then
+      report fail "download compose"
+      rc=1
+    elif ! curl -sL "${base_url}/${binary}.sha256" -o "$tmp_sum"; then
+      report fail "download compose checksum"
+      rc=1
+    elif ! (cd "$(dirname "$tmp_bin")" && sed "s|[^ ]*$|$(basename "$tmp_bin")|" "$tmp_sum" | sha256sum --check --status); then
+      report fail "compose checksum mismatch — binary discarded"
+      rc=1
+    else
+      install -m 0755 "$tmp_bin" "$compose_bin"
+      report fix "installed compose (checksum verified)"
+    fi
+
+    rm -f "$tmp_bin" "$tmp_sum"
+    [ "$rc" -eq 0 ] || return "$rc"
+  fi
+
+  if [ -L "$compose_plugin" ]; then
+    report ok "Compose plugin linked"
+  elif is_dry_run; then
+    report warn "Compose plugin symlink missing"
+  else
+    mkdir -p "$HOME/.docker/cli-plugins"
+    ln -sf "$compose_bin" "$compose_plugin"
+    report fix "linked compose plugin"
+  fi
+}
+
+ensure_containers_config() {
+  local conf="$HOME/.config/containers/containers.conf"
+
+  if grep -q "compose_providers" "$conf" 2>/dev/null; then
+    report ok "compose provider configured"
+    return 0
+  fi
+
+  if is_dry_run; then
+    report warn "containers.conf incomplete"
+    return 1
+  fi
+
+  local compose_plugin="$HOME/.docker/cli-plugins/docker-compose"
+  mkdir -p "$(dirname "$conf")"
+
+  [ -f "$conf" ] && echo >> "$conf"
+  cat >> "$conf" << EOF
+[engine]
+compose_warning_logs = false
+compose_providers = ["$compose_plugin"]
+EOF
+  report fix "configured containers.conf"
+}
+
+ensure_nodocker_file() {
+  if [ -f /etc/containers/nodocker ]; then
+    report ok "nodocker exists"
+  elif is_dry_run; then
+    report warn "nodocker missing"
+  else
+    if run_sudo mkdir -p /etc/containers && run_sudo touch /etc/containers/nodocker; then
+      report fix "created nodocker"
+    else
+      report fail "nodocker"
+    fi
+  fi
+}
+
+ensure_registries_config() {
+  local reg_conf="$HOME/.config/containers/registries.conf.d/overleaf-toolkit.conf"
+  if [ -f "$reg_conf" ] && grep -qF '# overleaf-toolkit' "$reg_conf" 2>/dev/null; then
+    report ok "registries.conf.d drop-in configured"
+  elif is_dry_run; then
+    report warn "registries.conf.d drop-in missing"
+  else
+    mkdir -p "$(dirname "$reg_conf")"
+    cat > "$reg_conf" << EOF
+# overleaf-toolkit managed configuration
+[aliases]
+"mongo" = "docker.io/library/mongo"
+"redis" = "docker.io/library/redis"
+EOF
+    report fix "configured registries.conf.d drop-in"
+  fi
+}
+
+ensure_container_runtime() {
+  heading "Container Runtime"
+
+  ensure_nodocker_file
+  ensure_registries_config
+  ensure_docker_compose
+  ensure_containers_config
+  ensure_docker_host
+  ensure_docker_socket
+}
+
+ensure_registry_auth() {
+  heading "Registry Auth"
+  # shellcheck disable=SC2153  # QUAY_LOGIN_STATUS set by lib/shared-functions.sh
+  check_quay_login
+
+  if [[ "$QUAY_LOGIN_STATUS" == true ]]; then
+    report ok "quay.io credentials valid"
+    return 0
+  fi
+
+  report warn "quay.io auth missing or invalid"
+  is_apply && printf "\n    Run 'podman login quay.io' to authenticate.\n\n"
+}
+
+check_loaded_selinux_policy() {
+  local sudo_cmd="$1"
+  # shellcheck disable=SC2153  # SELINUX_* set by lib/shared-functions.sh
+  check_selinux_module "$sudo_cmd"
+  if [[ "$SELINUX_MODULE_LOADED" == true ]]; then
+    report ok "SELinux module loaded"
+
+    check_selinux_rules "$sudo_cmd"
+    if [[ "$SELINUX_RULES_OK" == true ]]; then
+      report ok "SELinux rules verified"
+    elif is_dry_run; then
+      report warn "SELinux rules incomplete"
+    else
+      for rule in "${SELINUX_MISSING_RULES[@]}"; do
+        report fail "Rule missing: $rule"
+      done
+    fi
+    return 0
+  fi
+  return 1
+}
+
+ensure_selinux_policy() {
+  heading "SELinux Policy"
+
+  if is_dry_run; then
+    check_loaded_selinux_policy "sudo -n" || report warn "SELinux module status unknown (requires sudo)"
+    return 0
+  fi
+
+  check_loaded_selinux_policy "run_sudo" && return 0
+
+  # Install SELinux module
+  local dir="$HOME/.overleaf/selinux"
+  mkdir -p "$dir"
+
+  cp "$TOOLKIT_ROOT/lib/podman_socket_clsi.te" "$dir/podman_socket_clsi.te" || { report fail "copy SELinux policy"; return 1; }
+
+  if checkmodule -M -m -o "$dir/podman_socket_clsi.mod" "$dir/podman_socket_clsi.te" && \
+     semodule_package -o "$dir/podman_socket_clsi.pp" -m "$dir/podman_socket_clsi.mod" && \
+     run_sudo semodule -i "$dir/podman_socket_clsi.pp" 2>/dev/null; then
+    report fix "compiled and loaded SELinux module"
+  else
+    report fail "compile/load SELinux module"
+    return 1
+  fi
+}
+
+ensure_socket_connectivity() {
+  heading "Socket Connectivity"
+  local sock_path
+  sock_path="$(get_podman_socket_path)"
+
+  # shellcheck disable=SC2153  # SOCKET_PING_* set by lib/shared-functions.sh
+  test_socket_ping_host "$sock_path"
+  if [[ "$SOCKET_PING_HOST_OK" == true ]]; then
+    report ok "Host -> socket OK"
+  elif [[ "$SOCKET_PING_HOST_OUTPUT" == "socket not found" ]]; then
+    report warn "socket not found, is podman.socket running?"
+  else
+    report fail "Host -> socket failed ($SOCKET_PING_HOST_OUTPUT)"
+  fi
+
+  test_socket_ping_container
+  if [[ "$SOCKET_PING_CONTAINER_OK" == true ]]; then
+    report ok "Container -> socket OK"
+  elif [[ "$SOCKET_PING_CONTAINER_OUTPUT" == "sharelatex not running" ]]; then
+    report warn "sharelatex not running (skip container socket test)"
+  else
+    report fail "Container -> socket failed ($SOCKET_PING_CONTAINER_OUTPUT)"
+  fi
+}
+
+ensure_seccomp() {
+  heading "Seccomp"
+  local seccomp_path
+  seccomp_path="$(get_seccomp_expected_path)"
+  local bundled="$TOOLKIT_ROOT/lib/clsi-profile.json"
+
+  if [ -f "$seccomp_path" ]; then
+    report ok "Seccomp profile exists"
+  elif is_dry_run; then
+    report warn "Seccomp profile not installed"
+  elif [ ! -f "$bundled" ]; then
+    report fail "bundled seccomp profile not found"
+  else
+    mkdir -p "$HOME/.overleaf/seccomp"
+    if cp "$bundled" "$seccomp_path"; then
+      report fix "copied seccomp profile"
+    else
+      report fail "copy seccomp profile"
+    fi
+  fi
+
+  # shellcheck disable=SC2153  # SECCOMP_ENV_* set by lib/shared-functions.sh
+  check_seccomp_config
+  if [[ "$SECCOMP_ENV_MATCHES" == true ]]; then
+    report ok "SECCOMP_PROFILE correct"
+  elif is_dry_run; then
+    if [[ -n "$SECCOMP_ENV_VALUE" ]]; then
+      report warn "SECCOMP_PROFILE is '$SECCOMP_ENV_VALUE', expected '$seccomp_path'"
+    else
+      report warn "SECCOMP_PROFILE not set"
+    fi
+  else
+    set_config_var "SECCOMP_PROFILE" "$seccomp_path" "$TOOLKIT_ROOT/config/variables.env"
+    report fix "SECCOMP_PROFILE set"
+  fi
+}
+
+ensure_data_permissions() {
+  heading "Data Directory Permissions"
+
+  local mongo_data
+  mongo_data="$(read_configuration "MONGO_DATA_PATH")"
+  mongo_data="${mongo_data:-data/mongo}"
+  local redis_data
+  redis_data="$(read_configuration "REDIS_DATA_PATH")"
+  redis_data="${redis_data:-data/redis}"
+  local overleaf_data
+  overleaf_data="$(read_configuration "OVERLEAF_DATA_PATH")"
+  overleaf_data="${overleaf_data:-data/sharelatex}"
+
+  for entry in "mongo:${mongo_data}:999" "redis:${redis_data}:999" "overleaf:${overleaf_data}:33"; do
+    IFS=':' read -r name dir uid <<< "$entry"
+    local full_path="$TOOLKIT_ROOT/$dir"
+
+    if [ ! -d "$full_path" ]; then
+      report skip "$name data dir not found"
+      continue
+    fi
+
+    local actual_uid
+    actual_uid="$(podman unshare stat -c %u "$full_path" 2>/dev/null || echo "")"
+
+    if [ "$actual_uid" = "$uid" ]; then
+      report ok "$name data dir owned by $uid"
+    elif is_dry_run; then
+      report fail "$name data dir owned by '${actual_uid:-unknown}', expected $uid"
+    else
+      if podman unshare chown -R "${uid}:${uid}" "$full_path" 2>/dev/null; then
+        report fix "$name data dir ownership corrected"
+      else
+        report fail "$name data dir permissions"
+      fi
+    fi
+  done
+}
+
+reset_results() {
+  CHECK_PASS=0; CHECK_WARN=0; CHECK_FAIL=0; SUMMARY=""
+}
+
+print_result_counts() {
+  heading "Summary"
+  printf "[✓] %d passed  [!] %d warnings  [✗] %d failures\n" "$CHECK_PASS" "$CHECK_WARN" "$CHECK_FAIL"
+}
+
+run_check() {
+  local fn="$1"
+  local pass_before=$CHECK_PASS warn_before=$CHECK_WARN fail_before=$CHECK_FAIL
+  local rc=0
+  "$fn" || rc=$?
+  if [ "$rc" -ne 0 ] \
+     && [ "$CHECK_PASS" -eq "$pass_before" ] \
+     && [ "$CHECK_WARN" -eq "$warn_before" ] \
+     && [ "$CHECK_FAIL" -eq "$fail_before" ]; then
+    report fail "$fn aborted (exit $rc, no status reported)"
+  fi
+  return 0
+}
+
+run_common_checks() {
+  local include_socket_check="${1:-false}"
+
+  run_check ensure_lingering
+  run_check ensure_packages
+  run_check ensure_podman_socket
+  run_check ensure_container_runtime
+  run_check ensure_registry_auth
+  run_check ensure_selinux_policy
+  if [ "$include_socket_check" = true ]; then
+    run_check ensure_socket_connectivity
+  fi
+  run_check ensure_data_permissions
+  run_check ensure_seccomp
+}
+
+run_checks() {
+  reset_results
+  run_common_checks true
+
+  print_result_counts
+}
+
+run_fixes() {
+  reset_results
+  run_common_checks false
+  print_result_counts
+}
+
+is_failure() { [ "$CHECK_FAIL" -gt 0 ]; }
+is_warn() { [ "$CHECK_WARN" -gt 0 ]; }
+
+print_summary() {
+  local label="${1:-}"
+  if is_failure; then
+    printf "[✗] Failures%s:\n%s\n" "$label" "$(printf '%s' "$SUMMARY" | grep '^\[✗\]')"
+  fi
+  if is_warn; then
+    printf "[!] Warnings%s:\n%s\n" "$label" "$(printf '%s' "$SUMMARY" | grep '^\[!\]')"
+  fi
+}
+
+DRY_RUN=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) DRY_RUN=false; shift ;;
+    help|--help)
+      cat <<'HELP'
+Usage: bin/podman-setup [OPTIONS]
+
+Validates a RHEL-based system for Overleaf Server Pro
+with rootless Podman, sibling containers and SELinux enforcing.
+
+By default, this script checks for issues without fixing them.
+Use --apply to automatically fix detected issues.
+
+Options:
+  --apply       Fix detected issues (default: dry-run only)
+  --help        Show this help and exit
+HELP
+      exit
+      ;;
+    *) echo "Usage: $0 [--apply]" >&2; exit 2 ;;
+  esac
+done
+
+echo "=== Podman Setup ==="
+
+run_checks
+print_summary
+
+rc=0
+is_failure && rc=2
+[ "$rc" -eq 0 ] && is_warn && rc=1
+
+if is_apply && [ "$rc" -ne 0 ]; then
+  printf "\n====== Applying fixes ======\n"
+  sudo -v || { echo "ERROR: sudo authentication required for --apply" >&2; exit 2; }
+  run_fixes
+  printf "\n====== Re-checking ======\n"
+  run_checks
+  print_summary " remaining"
+  rc=0
+  is_failure && rc=2
+  [ "$rc" -eq 0 ] && is_warn && rc=1
+fi
+
+[ "$rc" -eq 0 ] && echo "All checks passed!"
+exit "$rc"

--- a/lib/clsi-profile.json
+++ b/lib/clsi-profile.json
@@ -1,0 +1,856 @@
+{
+    "defaultAction": "SCMP_ACT_ERRNO",
+    "architectures": [
+        "SCMP_ARCH_X86_64",
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+    ],
+    "syscalls": [
+        {
+          "name": "getrandom",
+          "action": "SCMP_ACT_ALLOW",
+          "args": []
+        },
+        {
+            "name": "access",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "arch_prctl",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "brk",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "chdir",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "chmod",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "clock_getres",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "clock_gettime",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "clock_nanosleep",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "clone",
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 2080505856,
+                    "valueTwo": 0,
+                    "op": "SCMP_CMP_MASKED_EQ"
+                }
+            ]
+        },
+        {
+            "name": "clone3",
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 38
+        },
+        {
+            "name": "close",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "copy_file_range",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "creat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "dup",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "dup2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "dup3",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "execve",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "execveat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "exit",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "exit_group",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "faccessat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fadvise64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fadvise64_64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fallocate",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fchdir",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fchmod",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fchmodat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fcntl",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fcntl64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fdatasync",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fork",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstat64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstatat64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstatfs",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstatfs64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fsync",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "ftruncate",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "ftruncate64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "futex",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "futimesat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getcpu",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getcwd",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getdents",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getdents64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getegid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getegid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "geteuid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "geteuid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getgid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getgid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getgroups",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getgroups32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getpgid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getpgrp",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getpid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getppid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getpriority",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getresgid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getresgid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getresuid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getresuid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getrlimit",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "get_robust_list",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getrusage",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getsid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "gettid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getuid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getuid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "ioctl",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "kill",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "_llseek",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "lseek",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "lstat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "lstat64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "madvise",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mkdir",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mkdirat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mmap",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mmap2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mprotect",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mremap",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "munmap",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "newfstatat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "open",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "openat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "openat2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pause",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pipe",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pipe2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "prctl",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pread64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "preadv",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "prlimit64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pwrite64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pwritev",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "read",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "readlink",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "readlinkat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "readv",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rename",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "renameat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "renameat2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "restart_syscall",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rmdir",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigaction",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigpending",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigprocmask",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigqueueinfo",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigreturn",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigsuspend",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigtimedwait",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_tgsigqueueinfo",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_getaffinity",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_getparam",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_get_priority_max",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_get_priority_min",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_getscheduler",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_rr_get_interval",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_yield",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sendfile",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sendfile64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "setgroups",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "setgroups32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "set_robust_list",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "set_tid_address",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sigaltstack",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "stat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "statx",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "stat64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "statfs",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "statfs64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sync",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sync_file_range",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "syncfs",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sysinfo",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "tgkill",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_create",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_delete",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_getoverrun",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_gettime",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_settime",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "times",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "tkill",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "truncate",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "truncate64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "umask",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "uname",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "unlink",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "unlinkat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "utime",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "utimensat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "utimes",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "vfork",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "vhangup",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "wait4",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "waitid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "write",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "writev",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pread",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "setgid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "setuid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "capget",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "capset",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fchown",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+          "name": "gettimeofday",
+          "action": "SCMP_ACT_ALLOW",
+          "args": []
+        }, {
+          "name": "epoll_pwait",
+          "action": "SCMP_ACT_ALLOW",
+          "args": []
+        }
+    ]
+}

--- a/lib/docker-compose.base.yml
+++ b/lib/docker-compose.base.yml
@@ -6,7 +6,7 @@ services:
         image: "${IMAGE}"
         container_name: sharelatex
         volumes:
-            - "${OVERLEAF_DATA_PATH}:${OVERLEAF_IN_CONTAINER_DATA_PATH}"
+            - "${OVERLEAF_DATA_PATH}:${OVERLEAF_IN_CONTAINER_DATA_PATH}:z"
         ports:
             - "${OVERLEAF_LISTEN_IP:-127.0.0.1}:${OVERLEAF_PORT:-80}:80"
         environment:

--- a/lib/docker-compose.git-bridge.yml
+++ b/lib/docker-compose.git-bridge.yml
@@ -19,7 +19,3 @@ services:
             - ../config/variables.env
         user: root
         command: ["/server-pro-start.sh"]
-
-    sharelatex:
-      links:
-        - git-bridge

--- a/lib/docker-compose.mongo.yml
+++ b/lib/docker-compose.mongo.yml
@@ -7,7 +7,7 @@ services:
         command: "${MONGO_ARGS}"
         container_name: mongo
         volumes:
-            - "${MONGO_DATA_PATH}:/data/db"
+            - "${MONGO_DATA_PATH}:/data/db:z"
         expose:
             - 27017
         healthcheck:
@@ -20,5 +20,4 @@ services:
       depends_on:
         mongo:
           condition: service_healthy
-      links:
-        - mongo
+

--- a/lib/docker-compose.redis.yml
+++ b/lib/docker-compose.redis.yml
@@ -5,7 +5,7 @@ services:
         restart: always
         image: "${REDIS_IMAGE}"
         volumes:
-            - "${REDIS_DATA_PATH}:/data"
+            - "${REDIS_DATA_PATH}:/data:z"
         container_name: redis
         command: ${REDIS_COMMAND}
         expose:
@@ -15,5 +15,4 @@ services:
       depends_on:
         redis:
           condition: service_started
-      links:
-        - redis
+

--- a/lib/podman_socket_clsi.te
+++ b/lib/podman_socket_clsi.te
@@ -1,0 +1,17 @@
+module podman_socket_clsi 1.1;
+
+# This module grants the sharelatex container permission to
+# interact with the rootless Podman socket under SELinux enforcing.
+# The socket lives at /run/user/$UID/podman/podman.sock with context user_tmp_t.
+
+require {
+    type container_t;
+    type user_tmp_t;
+    type container_runtime_t;
+    class sock_file { write getattr };
+    class unix_stream_socket connectto;
+}
+
+allow container_t user_tmp_t:sock_file write;
+allow container_t user_tmp_t:sock_file getattr;
+allow container_t container_runtime_t:unix_stream_socket connectto;

--- a/lib/shared-functions.sh
+++ b/lib/shared-functions.sh
@@ -225,3 +225,170 @@ function read_configuration() {
   grep -E "^$name=" "$TOOLKIT_ROOT/config/overleaf.rc" \
   | sed -r "s/^$name=([\"']?)(.+)\1\$/\2/"
 }
+
+# Returns 0 if podman runtime is available (podman binary or docker shim)
+is_podman() {
+  command -v podman &>/dev/null && return 0
+
+  if command -v docker &>/dev/null; then
+    docker version 2>/dev/null | grep -qi podman && return 0
+  fi
+
+  return 1
+}
+
+# Check for quay.io login credentials.
+# Sets: QUAY_LOGIN_STATUS ("true" or "false")
+#       QUAY_LOGIN_USER (username if found, empty otherwise)
+check_quay_login() {
+  QUAY_LOGIN_STATUS=false
+  QUAY_LOGIN_USER=""
+
+  # Try podman --get-login first
+  if command -v podman &>/dev/null; then
+    QUAY_LOGIN_USER=$(podman login quay.io --get-login 2>/dev/null) || true
+    if [[ -n "$QUAY_LOGIN_USER" ]]; then
+      QUAY_LOGIN_STATUS=true
+      return
+    fi
+  fi
+
+  # Fall back to checking auth config files
+  local auth_file
+  for auth_file in \
+    "$HOME/.config/containers/auth.json" \
+    "$HOME/.docker/config.json" \
+    "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/containers/auth.json"; do
+    if [[ -f "$auth_file" ]] && grep -q "quay.io" "$auth_file" 2>/dev/null; then
+      QUAY_LOGIN_STATUS=true
+      local auth_b64
+      auth_b64=$(awk '/"quay.io"/{f=1} f&&/"auth"/{gsub(/.*"auth": *"/,""); gsub(/".*/,""); print; exit}' "$auth_file" 2>/dev/null) || true
+      if [[ -n "$auth_b64" ]]; then
+        QUAY_LOGIN_USER=$(printf '%s' "$auth_b64" | base64 -d 2>/dev/null | cut -d: -f1) || true
+      fi
+      return
+    fi
+  done
+}
+
+resolve_socket_path() {
+  RESOLVED_SOCKET_PATH=""
+
+  if [[ -f "$TOOLKIT_ROOT/config/overleaf.rc" ]]; then
+    # shellcheck disable=SC1090
+    source "$TOOLKIT_ROOT/config/overleaf.rc"
+  fi
+
+  if [[ -n "${DOCKER_SOCKET_PATH:-}" ]]; then
+    RESOLVED_SOCKET_PATH="$DOCKER_SOCKET_PATH"
+  elif [[ -n "${DOCKER_HOST:-}" ]]; then
+    RESOLVED_SOCKET_PATH="${DOCKER_HOST#unix://}"
+  elif [[ -S "/var/run/docker.sock" ]]; then
+    RESOLVED_SOCKET_PATH="/var/run/docker.sock"
+  else
+    local runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    if [[ -S "$runtime_dir/podman/podman.sock" ]]; then
+      RESOLVED_SOCKET_PATH="$runtime_dir/podman/podman.sock"
+    fi
+  fi
+}
+
+test_socket_ping_host() {
+  local socket_path="$1"
+  SOCKET_PING_HOST_OK=false
+  SOCKET_PING_HOST_OUTPUT="socket not found"
+
+  if [[ ! -S "$socket_path" ]]; then
+    return
+  fi
+
+  if ! command -v curl &>/dev/null; then
+    SOCKET_PING_HOST_OUTPUT="curl not available"
+    return
+  fi
+
+  SOCKET_PING_HOST_OUTPUT=$(curl -s --max-time 3 --unix-socket "$socket_path" http://localhost/_ping 2>&1) || true
+  if [[ "$SOCKET_PING_HOST_OUTPUT" == "OK" ]]; then
+    SOCKET_PING_HOST_OK=true
+  fi
+}
+
+test_socket_ping_container() {
+  local docker_cmd="${1:-docker}"
+  SOCKET_PING_CONTAINER_OK=false
+  SOCKET_PING_CONTAINER_OUTPUT="sharelatex not running"
+
+  if $docker_cmd ps --format '{{.Names}}' 2>/dev/null | grep -qx sharelatex; then
+    SOCKET_PING_CONTAINER_OUTPUT=$($docker_cmd exec sharelatex sh -c 'curl -s --max-time 3 --unix-socket /var/run/docker.sock http://localhost/_ping 2>&1') || true
+    if [[ "$SOCKET_PING_CONTAINER_OUTPUT" == "OK" ]]; then
+      SOCKET_PING_CONTAINER_OK=true
+    fi
+  fi
+}
+
+get_seccomp_expected_path() {
+  echo "$HOME/.overleaf/seccomp/clsi-profile.json"
+}
+
+check_seccomp_config() {
+  local seccomp_path
+  seccomp_path=$(get_seccomp_expected_path)
+  local ve="$TOOLKIT_ROOT/config/variables.env"
+
+  SECCOMP_FILE_EXISTS=false
+  SECCOMP_ENV_MATCHES=false
+  SECCOMP_ENV_VALUE=""
+
+  if [[ -f "$seccomp_path" ]]; then
+    SECCOMP_FILE_EXISTS=true
+  fi
+
+  if [[ -f "$ve" ]]; then
+    SECCOMP_ENV_VALUE=$(grep "^SECCOMP_PROFILE=" "$ve" 2>/dev/null | tail -1 | sed 's/^SECCOMP_PROFILE=//; s/["'\'']//g') || true
+    if [[ "$SECCOMP_ENV_VALUE" == "$seccomp_path" ]]; then
+      SECCOMP_ENV_MATCHES=true
+    fi
+  fi
+}
+
+# Check if SELinux module is loaded.
+SELINUX_MODULE_NAME="podman_socket_clsi"
+SELINUX_RULES=(
+  "container_t container_runtime_t unix_stream_socket connectto"
+  "container_t user_tmp_t sock_file write"
+  "container_t user_tmp_t sock_file getattr"
+)
+
+# Check if SELinux module is loaded.
+# Args: $1 = sudo command (e.g. "sudo -n" or "run_sudo")
+# Sets: SELINUX_MODULE_LOADED (true/false)
+check_selinux_module() {
+  local sudo_cmd="${1:-sudo -n}"
+  SELINUX_MODULE_LOADED=false
+
+  if $sudo_cmd semodule -l 2>/dev/null | grep -q "^${SELINUX_MODULE_NAME}"; then
+    SELINUX_MODULE_LOADED=true
+  fi
+}
+
+# Verify SELinux module rules with sesearch.
+# Args: $1 = sudo command (e.g. "sudo -n" or "run_sudo")
+# Sets: SELINUX_RULES_OK (true/false), SELINUX_MISSING_RULES (array)
+check_selinux_rules() {
+  local sudo_cmd="${1:-sudo -n}"
+  SELINUX_RULES_OK=true
+  SELINUX_MISSING_RULES=()
+
+  if ! command -v sesearch &>/dev/null; then
+    return
+  fi
+
+  local rule
+  for rule in "${SELINUX_RULES[@]}"; do
+    read -r src target class perm <<< "$rule"
+    if ! $sudo_cmd sesearch --allow -s "$src" -t "$target" -c "$class" -p "$perm" 2>/dev/null | grep -q "allow"; then
+      SELINUX_RULES_OK=false
+      SELINUX_MISSING_RULES+=("$rule")
+    fi
+  done
+}


### PR DESCRIPTION
## Description

Adds support for running Overleaf Server Pro on rootless Podman (RHEL 9+ family), including sibling containers and SELinux enforcing mode.

Main changes:

- **New `bin/podman-setup` script** — validates and (with `--apply`) auto-fixes a RHEL-based host for rootless Podman: required packages, user lingering, the Podman user socket, `DOCKER_HOST` wiring in `config/overleaf.rc`, the seccomp profile, and the SELinux policy module. Exit codes distinguish all-clear / warnings / failures, and dry-run is the default.
- **New SELinux policy module (`lib/podman_socket_clsi.te`)** — allows the `sharelatex` container to connect to the rootless Podman socket for sibling-container compiles while SELinux stays in Enforcing mode.
- **New seccomp profile (`lib/clsi-profile.json`)** — profile for CLSI sandboxed compiles under Podman, wired up via `SECCOMP_PROFILE` in `variables.env`.
- **`bin/doctor` extended** — now reports the container runtime (Docker vs Podman), resolved socket path, `DOCKER_HOST` configuration, SELinux status/module/rules, seccomp profile presence, and host→socket / container→socket connectivity checks, with actionable warnings for each misconfiguration. The quay.io login check was also refactored into a shared helper.
- **`lib/shared-functions.sh`** — new shared helpers for Podman detection, socket path resolution, SELinux module/rule checks, seccomp config checks, and quay.io login detection, used by both `doctor` and `podman-setup`.
- **Compose file tweaks** — minor adjustments to the base, mongo, redis, and git-bridge compose files for Podman compatibility.

Existing Docker-based setups are unaffected: Podman-specific checks and warnings only activate when Podman is detected.

## Related issues / Pull Requests

<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz -->

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)